### PR TITLE
Add OS X 10.10+ as a valid deployment target

### DIFF
--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -28,6 +28,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   s.social_media_url = 'https://twitter.com/nordictweets'
 
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
 
   s.source_files = 'iOSDFULibrary/Classes/**/*'
 


### PR DESCRIPTION
We're updating the firmware of our BLE devices also from our OS X App.

This DFU Library works out-of-the-box when OS X 10.10+ is added as a deployment target.

I have tested the functionality of DFU on OS X and it works very well.

At least OS X 10.10 is required due to certain OS X API calls within the DFU library code.
