### PR TITLE
rename initPacket for naming convention compatibility

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iOSDFULibrary/Classes/Utilities/DFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Utilities/DFU/DFUExecutor.swift
@@ -79,7 +79,7 @@ internal class DFUExecutor : DFUPeripheralDelegate {
     // MARK: - DFU Peripheral Delegate methods
     
     func onDeviceReady() {
-        if firmware.initPacket == nil && peripheral.isInitPacketRequired() {
+        if firmware.currentInitPacket == nil && peripheral.isInitPacketRequired() {
             didErrorOccur(DFUError.ExtendedInitPacketRequired, withMessage: "The init packet is required by the target device")
             return
         }
@@ -126,7 +126,7 @@ internal class DFUExecutor : DFUPeripheralDelegate {
     
     func onStartDfuSent() {
         // Check if the init packet is present for this part
-        if let initPacket = firmware.initPacket {
+        if let initPacket = firmware.currentInitPacket {
             peripheral.sendInitPacket(initPacket)
             return
         }

--- a/iOSDFULibrary/Classes/Utilities/DFU/DFUFirmware.swift
+++ b/iOSDFULibrary/Classes/Utilities/DFU/DFUFirmware.swift
@@ -169,8 +169,8 @@ The type of the BIN or HEX file.
         return stream!.data
     }
     
-    internal var initPacket:NSData? {
-        return stream!.initPacket
+    internal var currentInitPacket:NSData? {
+        return stream!.currentInitPacket
     }
     
     internal func hasNextPart() -> Bool {

--- a/iOSDFULibrary/Classes/Utilities/Streams/DFUStream.swift
+++ b/iOSDFULibrary/Classes/Utilities/Streams/DFUStream.swift
@@ -54,7 +54,7 @@ internal protocol DFUStream {
     /// The firmware data to be sent to the DFU target.
     var data:NSData { get }
     /// The whole init packet matching the current part. Data may be longer than 20 bytes.
-    var initPacket:NSData? { get }
+    var currentInitPacket:NSData? { get }
     
     /**
      Returns true if there is another part to be send.

--- a/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamBin.swift
+++ b/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamBin.swift
@@ -63,7 +63,7 @@ internal class DFUStreamBin : DFUStream {
         return binaries
     }
     
-    var initPacket:NSData? {
+    var currentInitPacket:NSData? {
         return initPacketBinaries
     }
     

--- a/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamHex.swift
+++ b/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamHex.swift
@@ -64,7 +64,7 @@ internal class DFUStreamHex : DFUStream {
         return binaries
     }
     
-    var initPacket:NSData? {
+    var currentInitPacket:NSData? {
         return initPacketBinaries
     }
     

--- a/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamZip.swift
+++ b/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamZip.swift
@@ -104,7 +104,7 @@ internal class DFUStreamZip : DFUStream {
     private var appInitPacket:NSData?
     
     private var currentBinaries:NSData?
-    private var currentInitPacket:NSData?
+    private var localCurrentInitPacket:NSData?
     
     private var softdeviceSize:UInt32 = 0
     private var bootloaderSize:UInt32 = 0
@@ -247,10 +247,10 @@ internal class DFUStreamZip : DFUStream {
                 }
                 else if systemBinaries != nil {
                     currentBinaries = systemBinaries
-                    currentInitPacket = systemInitPacket
+                    localCurrentInitPacket = systemInitPacket
                 } else {
                     currentBinaries = appBinaries
-                    currentInitPacket = appInitPacket
+                    localCurrentInitPacket = appInitPacket
                 }
                 
                 // If the ZIP file contains an app and a softdevice or bootloader,
@@ -310,8 +310,8 @@ internal class DFUStreamZip : DFUStream {
         return currentBinaries!
     }
     
-    var initPacket:NSData? {
-        return currentInitPacket
+    var currentInitPacket:NSData? {
+        return localCurrentInitPacket
     }
     
     func hasNextPart() -> Bool {
@@ -323,7 +323,7 @@ internal class DFUStreamZip : DFUStream {
             currentPart = 2
             currentPartType = FIRMWARE_TYPE_APPLICATION
             currentBinaries = appBinaries
-            currentInitPacket = appInitPacket
+            localCurrentInitPacket = appInitPacket
         }
     }
 }


### PR DESCRIPTION
**Description**

Incorporating this Swift framework into an objective-c application causes failures when building the module due to the use of `init` (see http://clang.llvm.org/docs/AutomaticReferenceCounting.html#method-families).  Changing the variable name fixes the problem.

**STR**
1. add `iOSDFULibrary` as a pod in to an objective-c application.
2. make sure you specify `use_frameworks!` in the the pod3file
3. import the iOSDFULibrary module in one of the class implementation files
4. compile

**What happened**
1. fails with error `init methods must return a type related to the receiver type`
