### PR TITLE
Fix the suggested Podfile contents

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -34,10 +34,11 @@ To include the library in your project do one of those options:
 
 1. Cocoapods (recommended):
 
-   Open up a terminal window, cd to your project's root and create a `Podfile` with the follwoing content:
+   Open up a terminal window, cd to your project's root and create a `Podfile` with the following content. Replace "YourAppTargetName" with the name of the main target in your app.
 
-   ```
-   use_frameworks!
+   ```ruby
+   target 'YourAppTargetName' do
+       use_frameworks!
        pod 'iOSDFULibrary'
    end
    ```


### PR DESCRIPTION
The Podfile contents supplied in the README are invalid. If you only include the three lines provided, pod install throws this error:

> Invalid Podfile file: syntax error, unexpected keyword_end, expecting end-of-input.

You need to specify the target.

This is related to https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/pull/13