### PR TITLE
Added Cartfile to handle Zip dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "marmelroy/Zip" ~> 0.6


### PR DESCRIPTION
For developers using Carthage, there is a slight issue in that currently the Zip dependency isn't explicitly stated. Given that Zip is a dependency for the DFU Library, I think it makes sense for this library to have its own Cartfile so that there isn't this confusion about a build error looking for the 'Zip' library.

I've added the appropriate Cartfile and am now able to build our application without the error about 'Zip'. Went ahead and incremented the least significant digit in the semantic versioning, and tagged this commit with v2.1.2, though if you merge this PR I'm not sure if you want to keep things at 2.1.1 or increment to 2.1.2 @mostafaberg ? If incrementing to 2.1.2, I think there are some other files that likely need to be made consistent as well, but I wanted to wait to get your thoughts.
