### PR TITLE
Adding option to disable rename feature , Fixes #159

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
@@ -44,7 +44,7 @@ import CoreBluetooth
  In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded devices which allows to send a unique name
  to the device before it is switched to bootloader mode. After jump, the bootloader will advertise with this name
  as the Complete Local Name making it easy to select proper device. In this case you don't have to override the default
- peripheral selector.
+ peripheral selector. More: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
  */
 @objc public protocol DFUPeripheralSelectorDelegate : class {
     /**

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -137,16 +137,16 @@ import CoreBluetooth
      
      Read more: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
      
-     Setting this flag to true you may disable this feature. iOS DFU Library will not send the 0x02-[len]-[new name]
+     Setting this flag to false you will disable this feature. iOS DFU Library will not send the 0x02-[len]-[new name]
      command prior jumping and will rely on the DfuPeripheralSelectorDelegate just like it used to in previous SDK.
      
      This flag is ignored in Legacy DFU.
      
-     **It is recommended to keep this flag set to false unless necessary.**
+     **It is recommended to keep this flag set to true unless necessary.**
      
      For more information read: https://github.com/NordicSemiconductor/IOS-nRF-Connect/issues/16
      */
-    @objc public var disableSettingAlternativeAdvertisingName = false
+    @objc public var alternativeAdvertisingNameEnabled = true
     
     /**
      Set this flag to true to enable experimental buttonless feature in Secure DFU. When the 

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -130,6 +130,25 @@ import CoreBluetooth
     @objc public var forceDfu = false
     
     /**
+     In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded devices which allows to send a unique name
+     to the device before it is switched to bootloader mode. After jump, the bootloader will advertise with this name
+     as the Complete Local Name making it easy to select proper device. In this case you don't have to override the default
+     peripheral selector.
+     
+     Read more: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
+     
+     Setting this flag to true you may disable this feature. iOS DFU Library will not send the 0x02-[len]-[new name]
+     command prior jumping and will rely on the DfuPeripheralSelectorDelegate just like it used to in previous SDK.
+     
+     This flag is ignored in Legacy DFU.
+     
+     **It is recommended to keep this flag set to false unless necessary.**
+     
+     For more information read: https://github.com/NordicSemiconductor/IOS-nRF-Connect/issues/16
+     */
+    @objc public var disableSettingAlternativeAdvertisingName = false
+    
+    /**
      Set this flag to true to enable experimental buttonless feature in Secure DFU. When the 
      experimental Buttonless DFU Service is found on a device, the service will use it to
      switch the device to the bootloader mode, connect to it in that mode and proceed with DFU.

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -190,7 +190,7 @@ import CoreBluetooth
      
      - parameter report:  method called when an error occurred
      */
-    func jumpToBootloaderMode(onError report:@escaping ErrorCallback) {
+    func jumpToBootloaderMode(onError report: @escaping ErrorCallback) {
         if !aborted {
             dfuControlPointCharacteristic!.send(Request.jumpToBootloader, onSuccess: nil, onError: report)
         } else {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -24,6 +24,9 @@ import CoreBluetooth
 
 internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, SecureDFUService> {
     
+    /// A flag indicating whether setting alternative advertising name is disabled (false by default)
+    internal let disableSettingAlternativeAdvertisingName: Bool
+    
     // MARK: - Peripheral API
     
     override var requiredServices: [CBUUID]? {
@@ -36,6 +39,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     }
     
     // MARK: - Implementation
+    
+    override init(_ initiator: DFUServiceInitiator) {
+        self.disableSettingAlternativeAdvertisingName = initiator.disableSettingAlternativeAdvertisingName
+        super.init(initiator)
+    }
     
     /**
      Enables notifications on DFU Control Point characteristic.
@@ -65,7 +73,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func jumpToBootloader() {
         jumpingToBootloader = true
         newAddressExpected = dfuService!.newAddressExpected
-        dfuService!.jumpToBootloaderMode(
+        dfuService!.jumpToBootloaderMode(dontSetAdvertisingName: disableSettingAlternativeAdvertisingName,
             // onSuccess the device gets disconnected and centralManager(_:didDisconnectPeripheral:error) will be called
             onError: { (error, message) in
                 self.jumpingToBootloader = false

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -24,8 +24,8 @@ import CoreBluetooth
 
 internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, SecureDFUService> {
     
-    /// A flag indicating whether setting alternative advertising name is disabled (false by default)
-    internal let disableSettingAlternativeAdvertisingName: Bool
+    /// A flag indicating whether setting alternative advertising name is enabled (SDK 14+) (true by default)
+    internal let alternativeAdvertisingNameEnabled: Bool
     
     // MARK: - Peripheral API
     
@@ -41,7 +41,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     // MARK: - Implementation
     
     override init(_ initiator: DFUServiceInitiator) {
-        self.disableSettingAlternativeAdvertisingName = initiator.disableSettingAlternativeAdvertisingName
+        self.alternativeAdvertisingNameEnabled = initiator.alternativeAdvertisingNameEnabled
         super.init(initiator)
     }
     
@@ -73,7 +73,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func jumpToBootloader() {
         jumpingToBootloader = true
         newAddressExpected = dfuService!.newAddressExpected
-        dfuService!.jumpToBootloaderMode(dontSetAdvertisingName: disableSettingAlternativeAdvertisingName,
+        dfuService!.jumpToBootloaderMode(withAlternativeAdvertisingName: alternativeAdvertisingNameEnabled,
             // onSuccess the device gets disconnected and centralManager(_:didDisconnectPeripheral:error) will be called
             onError: { (error, message) in
                 self.jumpingToBootloader = false

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -461,14 +461,14 @@ import CoreBluetooth
      
      - parameter report: method called when an error occurred
      */
-    func jumpToBootloaderMode(onError report: @escaping ErrorCallback) {
+    func jumpToBootloaderMode(dontSetAdvertisingName: Bool, onError report: @escaping ErrorCallback) {
         if !aborted {
             func enterBootloader() {
                 self.buttonlessDfuCharacteristic!.send(ButtonlessDFURequest.enterBootloader, onSuccess: nil, onError: report)
             }
             
             // If the characteristic may support changing bootloader's name, try it
-            if buttonlessDfuCharacteristic!.maySupportSettingName {
+            if dontSetAdvertisingName == false && buttonlessDfuCharacteristic!.maySupportSettingName {
                 // Generate a random 8-character long name
                 let name = String(format: "Dfu%05d", arc4random_uniform(100000))
                 

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -461,14 +461,14 @@ import CoreBluetooth
      
      - parameter report: method called when an error occurred
      */
-    func jumpToBootloaderMode(dontSetAdvertisingName: Bool, onError report: @escaping ErrorCallback) {
+    func jumpToBootloaderMode(withAlternativeAdvertisingName rename: Bool, onError report: @escaping ErrorCallback) {
         if !aborted {
             func enterBootloader() {
                 self.buttonlessDfuCharacteristic!.send(ButtonlessDFURequest.enterBootloader, onSuccess: nil, onError: report)
             }
             
-            // If the characteristic may support changing bootloader's name, try it
-            if dontSetAdvertisingName == false && buttonlessDfuCharacteristic!.maySupportSettingName {
+            // If the device may support setting alternative advertising name in the bootloader mode, try it
+            if rename && buttonlessDfuCharacteristic!.maySupportSettingName {
                 // Generate a random 8-character long name
                 let name = String(format: "Dfu%05d", arc4random_uniform(100000))
                 


### PR DESCRIPTION
Option to disable setting the alternative advertising name. This is required by some customers that had released a device that crashes when this feature is being used. It's better to update a device without this feature then not update it at all.