### PR TITLE
Using new API to remove need for PRNs

### DIFF
--- a/Example/iOSDFULibrary/DFUViewController.swift
+++ b/Example/iOSDFULibrary/DFUViewController.swift
@@ -109,6 +109,13 @@ class DFUViewController: UIViewController, CBCentralManagerDelegate, CBPeriphera
         dfuInitiator.delegate = self
         dfuInitiator.progressDelegate = self
         dfuInitiator.logger = self
+        // Starting from iOS 11 and macOS 10.13 there is a new API that removes the need of PRNs.
+        // However, some devices may still work better with them enabled! A specially those
+        // based on SDK older than 8.0 where the flash saving was slower and modern phones
+        // can send data faster then that which causes the DFU bootloader to abort with an error.
+        if #available(iOS 11.0, macOS 10.13, *) {
+            dfuInitiator.packetReceiptNotificationParameter = 0
+        }
         
         // This enables the experimental Buttonless DFU feature from SDK 12.
         // Please, read the field documentation before use.

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -74,8 +74,18 @@ import CoreBluetooth
      The number of packets of firmware data to be received by the DFU target before sending
      a new Packet Receipt Notification.
      If this value is 0, the packet receipt notification will be disabled by the DFU target.
-     Default value is 12. Higher values (~20+), or disabling it, may speed up the upload process,
-     but also cause a buffer overflow and hang the Bluetooth adapter.
+     Default value is 12.
+     
+     PRNs are no longer required on iOS 11 and MacOS 10.13 or newer, but make sure
+     your device is able to be updated without. Old SDKs, before SDK 7 had very slow
+     memory management and could not handle packets that fast. If your device
+     is based on such SDK it is recommended to leave the default value.
+     
+     Disabling PRNs on iPhone 8 with iOS 11.1.2 increased the speed from 1.7 KB/s to 2.7 KB/s
+     on DFU from SDK 14.1 where packet size is 20 bytes (higher MTU not supported yet).
+     
+     On older versions, higher values of PRN (~20+), or disabling it, may speed up
+     the upload process, but also cause a buffer overflow and hang the Bluetooth adapter.
      Maximum verified values were 29 for iPhone 6 Plus or 22 for iPhone 7, both iOS 10.1.
      */
     @objc public var packetReceiptNotificationParameter: UInt16 = 12

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUService.swift
@@ -24,7 +24,7 @@ import CoreBluetooth
 
 internal typealias Callback = () -> Void
 internal typealias ErrorCallback = (_ error: DFUError, _ withMessage: String) -> Void
-internal typealias ProgressCallback = (_ bytesReceived: UInt32) -> Void
+internal typealias ProgressCallback = (_ bytesReceived: UInt32?) -> Void
 
 internal protocol DFUService : DFUController {
     /// The UUID of the service

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -401,4 +401,11 @@ internal struct PacketReceiptNotification {
             }
         }
     }
+    
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // On iOS 11 and MacOS 10.13 or newer PRS are no longer required. Instead,
+        // the service checks if it can write write without response before writing
+        // and it will get this callback if the buffer is ready again.
+        proceed?(nil) // no offset available
+    }
 }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -405,15 +405,23 @@ import CoreBluetooth
                     },
                     onPacketReceiptNofitication: {
                         bytesReceived in
+                        // This callback is called from SecureDFUControlPoint in 2 cases: when a PRN is received (bytesReceived contains number
+                        // of bytes reported), or when the iOS reports the peripheralIsReady(toSendWriteWithoutResponse:) callback
+                        // (bytesReceived is nil). If PRNs are enabled we ignore this second case as the PRNs are responsible for synchronization.
+                        let peripheralIsReadyToSendWriteWithoutRequest = bytesReceived == nil
+                        if self.packetReceiptNotificationNumber > 0 && peripheralIsReadyToSendWriteWithoutRequest {
+                            return
+                        }
+                        
                         // Each time a PRN is received, send next bunch of packets
                         if !self.paused && !self.aborted {
                             let bytesSent = self.dfuPacketCharacteristic!.bytesSent
                             // Due to https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/54 only 16 least significant bits are verified
-                            if (bytesSent & 0xFFFF) == (bytesReceived & 0xFFFF) {
+                            if peripheralIsReadyToSendWriteWithoutRequest || (bytesSent & 0xFFFF) == (bytesReceived! & 0xFFFF) {
                                 self.dfuPacketCharacteristic!.sendNext(self.packetReceiptNotificationNumber, packetsOf: aFirmware, andReportProgressTo: progressDelegate)
                             } else {
                                 // Target device deported invalid number of bytes received
-                                report(.bytesLost, "\(bytesSent) bytes were sent while \(bytesReceived) bytes were reported as received")
+                                report(.bytesLost, "\(bytesSent) bytes were sent while \(bytesReceived!) bytes were reported as received")
                             }
                         } else if self.aborted {
                             // Upload has been aborted. Reset the target device. It will disconnect automatically

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -504,4 +504,11 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate {
             }
         }
     }
+    
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // On iOS 11 and MacOS 10.13 or newer PRS are no longer required. Instead,
+        // the service checks if it can write write without response before writing
+        // and it will get this callback if the buffer is ready again.
+        proceed?(nil) // no offset available
+    }
 }


### PR DESCRIPTION
A change to make using PRN no longer required on iOS 11+.
Tested on iPhone 7 and 8 with iOS 11.1.2.

Comments:
- `peripheral.canSendWriteWithoutResponse` initially returns true OR false (no idea why false sometimes), so I check if `bytesSent == 0` to override it. Without it the `peripheralIsReady(toSendWriteWithoutResponse:)` is never called so the process just hangs at 0 bytes.
- PRNs are still required for older SDKs where memory management was slower than the BLE speed of modern phones. This is explained in the comments.