### PR TITLE
#170 fixed

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -71,6 +71,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func jumpToBootloader() {
         jumpingToBootloader = true
+        newAddressExpected = dfuService!.newAddressExpected
         dfuService!.jumpToBootloaderMode(
             // onSuccess the device gets disconnected and centralManager(_:didDisconnectPeripheral:error) will be called
             onError: { (error, message) in

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -172,6 +172,20 @@ import CoreBluetooth
     }
     
     /**
+     Returns whether the bootloader is expected to advertise with the same address on one incremented by 1.
+     In the latter case the library needs to scan for a new advertising device and select it by filtering the adv packet,
+     as device address is not available through iOS API.
+     */
+    var newAddressExpected: Bool {
+        // See https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/170 and
+        // https://github.com/NordicSemiconductor/Android-DFU-Library/pull/45
+        // The legacy bootloader will advertise with address +1 only in SDK 6.1. Future implementations
+        // of legacy DFU will advertise directly with the same address no matter whether the device was
+        // bonded or not. In SDK 6.1 there was no DFU Version characteristic.
+        return version == nil
+    }
+    
+    /**
      Enables notifications for DFU Control Point characteristic. Result it reported using callbacks.
      
      - parameter success: method called when notifications were enabled without a problem


### PR DESCRIPTION
This change is related to https://github.com/NordicSemiconductor/Android-DFU-Library/pull/45 and #170.
According to https://github.com/NordicSemiconductor/Android-DFU-Library/pull/45#issuecomment-283933079 in SDK 6.1 the DFU Buttonless service wasn't implemented, so this change will affect only custom made buttonless services and should have no affect on other implementations.