### PR TITLE
Release 4.1.1

### DIFF
--- a/Example/iOSDFULibrary/Info.plist
+++ b/Example/iOSDFULibrary/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.0</string>
+	<string>4.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>42</string>
+	<string>43</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Example/macOS-DFU-Example/Info.plist
+++ b/Example/macOS-DFU-Example/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>4.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>43</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/changelog
+++ b/changelog
@@ -1,5 +1,13 @@
 ### Changelog
 
+- **4.1.1**
+    - Bugfix: Fixed an issue with DFU processes that had multiple DFU parts that caused the executor to connect to wrong peripherals after flashing the first part.
+	      The peripheral is now held in memory until it comes back online, so the library will no longer scan for DFU peripherals while waiting for it to restart.
+    - Bugfix: Fixed an issue related to the new address expected flag.
+    - Improvement: Carthage support for MacOS.
+    - Improvement: Firmware size information is now available for Obj-C projects.
+    - Improvement: Added required imports for projects built without Cocoapods.
+
 - **4.1.0**
     - Improvement: Using iOS 11's new `canSendWriteWithoutResponse` API to remove the need of using packet receipt notifications, setting a PRN value of 0 on iOS 11 will enable this feature.
     - PRN will still be used as the default option.

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
-  s.version          = "4.1.0"
+  s.version          = "4.1.1"
   s.summary          = "This repository contains a tested library for iOS 8+ devices to perform Device Firmware Update on the nRF5x devices"
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -137,15 +137,14 @@ extension DFUExecutor {
     
     // MARK: - BasePeripheralDelegate API
     
-    func peripheralDidDisconnectAfterFirmwarePartSent() {
+    func peripheralDidDisconnectAfterFirmwarePartSent() -> Bool {
         // Check if there is another part of the firmware that has to be sent
         if firmware.hasNextPart() {
             firmware.switchToNextPart()
             DispatchQueue.main.async(execute: {
                 self.delegate?.dfuStateDidChange(to: .connecting)
             })
-            peripheral.switchToNewPeripheralAndConnect()
-            return
+            return true
         }
         // If not, we are done here. Congratulations!
         DispatchQueue.main.async(execute: {
@@ -155,5 +154,6 @@ extension DFUExecutor {
             
         // Release the cyclic reference
         peripheral.destroy()
+        return false
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -476,8 +476,10 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
             }
         } else if activating {
             activating = false
-            // This part of firmware has been successfully
-            delegate?.peripheralDidDisconnectAfterFirmwarePartSent()
+            // This part of firmware has been successfully sent
+            if (delegate?.peripheralDidDisconnectAfterFirmwarePartSent() ?? false) {
+                connect()
+            }
         } else {
             super.peripheralDidDisconnect()
         }

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
@@ -70,5 +70,5 @@ internal protocol DFUPeripheralDelegate : BasePeripheralDelegate {
      a device advertising in DFU Bootloader mode, connect to it. The `peripheralDidBecomeReady()`
      callback will be called again when DFU service will be found in its database.
      */
-    func peripheralDidDisconnectAfterFirmwarePartSent()
+    func peripheralDidDisconnectAfterFirmwarePartSent() -> Bool
 }


### PR DESCRIPTION
* Bugfix: Fixed an issue with DFU processes that had multiple DFU parts that caused the executor to connect to wrong peripherals after flashing the first part. The peripheral is now held in memory until it comes back online, so the library will no longer scan for DFU peripherals while waiting for it to restart.
* Bugfix: Fixed an issue related to the new address expected flag.
* Improvement: Carthage support for MacOS.
* Improvement: Firmware size information is now available for Obj-C projects.
* Improvement: Added required imports for projects built without Cocoapods.