### PR TITLE
#179 fixed

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -135,7 +135,7 @@ internal protocol DFUExecutor : DFUExecutorAPI, BaseDFUExecutor, DFUPeripheralDe
 
 extension DFUExecutor {
     
-    // MARK: - BasePeripheralDelegate API
+    // MARK: - DFUPeripheralDelegate API
     
     func peripheralDidDisconnectAfterFirmwarePartSent() -> Bool {
         // Check if there is another part of the firmware that has to be sent

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -477,8 +477,21 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
         } else if activating {
             activating = false
             // This part of firmware has been successfully sent
+            
+            // Check if there is another part to be sent
             if (delegate?.peripheralDidDisconnectAfterFirmwarePartSent() ?? false) {
-                connect()
+                if newAddressExpected {
+                    newAddressExpected = false
+                    // Scan for a new device and connect to it
+                    switchToNewPeripheralAndConnect()
+                } else {
+                    // The same device can be used
+                    connect()
+                }
+            } else {
+                // Upload is completed.
+                // Peripheral has been destroyed and state is now .completed.
+                // There is nothing to be done here.
             }
         } else {
             super.peripheralDidDisconnect()

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
@@ -66,9 +66,14 @@ internal protocol DFUPeripheralDelegate : BasePeripheralDelegate {
      Callback called when the device got disconencted after the current part of
      the firmware has been sent, verified and activated. The iDevice is no longer
      conneted to the target device.
-     When there is another part of the firmware to be sent, the delegate should scan for
-     a device advertising in DFU Bootloader mode, connect to it. The `peripheralDidBecomeReady()`
-     callback will be called again when DFU service will be found in its database.
+     The delegate should return true if there is another part of the firmware to be sent
+     or false if upload has been completed.
+     When true is returned, the DFU service will reconnect to the same peripheral
+     or scan for the bootloader using the DFUPeripheralSelector specified in the
+     DFUServiceInitiator and continue with second part. The `peripheralDidBecomeReady()`
+     callback will be called again when DFU service is be found in its database.
+     
+     - returns: true if there is another part to be sent, false otherwise.
      */
     func peripheralDidDisconnectAfterFirmwarePartSent() -> Bool
 }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -173,6 +173,12 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func activateAndReset() {
         activating = true
+        
+        // In Legacy DFU the Buttonless service does not increment the device address.
+        // However, after sending the first part of the firmware, the device reboots
+        // and may use incremented MAC address to receive the second part.
+        newAddressExpected = true
+        
         dfuService!.sendActivateAndResetRequest(
             // onSuccess the device gets disconnected and centralManager(_:didDisconnectPeripheral:error) will be called
             onError: defaultErrorCallback


### PR DESCRIPTION
This PR should fix #179. Some testing should be done to ensure it works as before on Secure DFU and it is possible to update Bootloader and App in one ZIP using Legacy DFU. 
In my opinion Secure DFU was intact and in worst case it will scan for the same peripheral in Legacy DFU, so no harm was made.