### PR TITLE
Fixed update failures because of device disconnects

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -179,6 +179,10 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     }
     
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        guard peripheral.isEqual(self.peripheral) else {
+            return
+        }
+        
         cleanUp()
         
         logger.d("[Callback] Central Manager did connect peripheral")
@@ -194,6 +198,10 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     }
     
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        guard peripheral.isEqual(self.peripheral) else {
+            return
+        }
+        
         cleanUp()
         
         if let error = error {
@@ -207,6 +215,10 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     }
     
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        guard peripheral.isEqual(self.peripheral) else {
+            return
+        }
+        
         cleanUp()
         
         // We may expect an error with 


### PR DESCRIPTION
The problem this PR solves are "random" disconnect events during a firmware update. This happens because the lib is not checking if it is actually the to-be-updated peripheral that got disconnected. So if a completely unrelated device (or the same device with a different mac address) disconnects during the update, the update is aborted even though the target peripheral is still connected.

It's strange that this hasn't had a huge impact before (we may saw some cases without recognizing them), but I guess this may be related to changed timings caused by the latest iOS 11.3 update.

This fixes #177 and potentially a number of other issues.