### PR TITLE
+Updated changelog and Podspec for release 4.1.3

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,7 @@
 ### Changelog
-
+- **4.1.3**
+    - Bugfix: Fix by @simonseyer that resolves a random disconnects issue caused by the reuse of the same CBCentralManager used by the library, which received callbacks of device disconnects that might not be the target perpiheral
+    - Bugfix: Fix by @alanfischer that resolves an Xcode warning related to documentation.
 - **4.1.2**
     - Bugfix: Fixed an issue introduced in 4.1.1 that caused legacy DFU to fail on some devices
     - Bugfix: Fixed missing information in the documentation that explains how to enable the experimental buttonless DFU feature

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -1,14 +1,6 @@
-#
-# Be sure to run `pod lib lint iOSDFULibrary.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
-  s.version          = "4.1.2"
+  s.version          = "4.1.3"
   s.summary          = "This repository contains a tested library for iOS 8+ devices to perform Device Firmware Update on the nRF5x devices"
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.


### PR DESCRIPTION
Release 4.1.3:
- Bugfix: Fix by @simonseyer that resolves a random disconnects issue caused by the reuse of the same CBCentralManager used by the library, which received callbacks of device disconnects that might not be the target perpiheral
- Bugfix: Fix by @alanfischer that resolves an Xcode warning related to documentation.