### PR TITLE
Improved logging for the secure DFU update process

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -415,9 +415,6 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate {
         
         // Set the peripheral delegate to self
         peripheral.delegate = self
-        
-        logger.a("Uploading firmware...")
-        logger.v("Sending firmware to DFU Packet characteristic...")
     }
 
     // MARK: - Peripheral Delegate callbacks
@@ -456,7 +453,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate {
             // For bonded devices make sure it sends the Service Changed indication after connecting.
             report?(.writingCharacteristicFailed, "Writing to characteristic failed")
         } else {
-            logger.i("Data written to \(characteristic.uuid.uuidString)")
+            logger.v("Data written to \(characteristic.uuid.uuidString)")
         }
     }
     
@@ -480,7 +477,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate {
                 }
             }
             //Otherwise...    
-            logger.i("Notification received from \(characteristic.uuid.uuidString), value (0x): \(characteristic.value!.hexString)")
+            logger.v("Notification received from \(characteristic.uuid.uuidString), value (0x): \(characteristic.value!.hexString)")
 
             // Parse response received
             let dfuResponse = SecureDFUResponse(characteristic.value!)
@@ -488,13 +485,13 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate {
                 if dfuResponse.status == .success {
                     switch dfuResponse.requestOpCode! {
                     case .readObjectInfo, .calculateChecksum:
-                        logger.a("\(dfuResponse.description) received")
+                        logger.v("\(dfuResponse.description) received")
                         response?(dfuResponse)
                     case .createObject, .setPRNValue, .execute:
                         // Don't log, executor or service will do it for us
                         success?()
                     default:
-                        logger.a("\(dfuResponse.description) received")
+                        logger.v("\(dfuResponse.description) received")
                         success?()
                     }
                 } else if dfuResponse.status == .extendedError {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -133,7 +133,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
     }
     
     func peripheralDidReceiveInitPacket() {
-        logWith(.application, message: String(format: "Command object sent (CRC = %08X)", CRC32(data: firmware.initPacket!).crc))
+        logWith(.verbose, message: String(format: "Command object sent (CRC = %08X)", CRC32(data: firmware.initPacket!).crc))
         peripheral.sendCalculateChecksumCommand()
     }
     
@@ -167,11 +167,11 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
     
     func peripheralDidExecuteObject() {
         if initPacketSent == false {
-            logWith(.application, message: "Command object executed")
+            logWith(.verbose, message: "Command object executed")
             initPacketSent = true
             peripheral.readDataObjectInfo()
         } else {
-            logWith(.application, message: "Data object executed")
+            logWith(.verbose, message: "Data object executed")
             
             if firmwareSent == false {
                 currentRangeIdx += 1
@@ -201,6 +201,9 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
             firmwareRanges = calculateFirmwareRanges(Int(maxLen))
             currentRangeIdx = 0
         }
+        
+        logWith(.application, message: "Uploading firmware...")
+        logWith(.verbose, message: "Sending firmware to DFU Packet characteristic...")
         
         DispatchQueue.main.async(execute: {
             self.delegate?.dfuStateDidChange(to: .uploading)
@@ -261,7 +264,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
     }
     
     func peripheralDidCreateDataObject() {
-        logWith(.info, message: "Data object \(currentRangeIdx + 1)/\(firmwareRanges!.count) created")
+        logWith(.verbose, message: "Data object \(currentRangeIdx + 1)/\(firmwareRanges!.count) created")
         sendDataObject(currentRangeIdx)
     }
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -223,9 +223,9 @@ import CoreBluetooth
         dfuControlPointCharacteristic?.send(SecureDFURequest.setPacketReceiptNotification(value: aValue),
             onSuccess: {
                 if aValue > 0 {
-                    self.logger.a("Packet Receipt Notif enabled (Op Code = 2, Value = \(aValue))")
+                    self.logger.v("Packet Receipt Notif enabled (Op Code = 2, Value = \(aValue))")
                 } else {
-                    self.logger.a("Packet Receipt Notif disabled (Op Code = 2, Value = 0)")
+                    self.logger.v("Packet Receipt Notif disabled (Op Code = 2, Value = 0)")
                 }
                 success()
             },


### PR DESCRIPTION
In comparison to the legacy DFU update the logging of the secure update is a lot more verbose:
```
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 60030100e00000f549e947
Checksum (Offset = 57344, CRC = 47E949F5) received
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 600401
Data object executed
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 600101
Data object 15/38 created
Uploading firmware...
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 60030100e00000f549e947
Checksum (Offset = 57344, CRC = 47E949F5) received
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 600401
Data object executed
Data written to 8EC90001-F315-4F60-9FB8-838830DAEA50
Notification received from 8EC90001-F315-4F60-9FB8-838830DAEA50, value (0x): 600101
Data object 16/38 created
Uploading firmware...
```
(this repeats for every transmitted part of the firmware)

This PR aims to cut the logs down to a "normal" level which is closer to the behaviour of the legacy update:
```
Connected to XXX
Services discovered
Connected to XXX
Services discovered
-> Connecting
DFU characteristics discovered
-> Starting DFU
Secure DFU Control Point notifications enabled
Uploading firmware...
-> Uploading
Upload completed in 12.15 seconds
-> Disconnecting
Disconnected by the remote device
-> Completed
```
(the logs with arrows are the state changes that we log in our app, the rest are logs from the lib, `LogLevelInfo`)

Feel free to adress the "issue" in a different way or to modify my changes. That's just how it seems to work out for us.