### PR TITLE
Correct misspelled word [Firmare -> Firmware]

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -251,7 +251,7 @@ import CoreBluetooth
     @objc public func start() -> DFUServiceController? {
         // The firmware file must be specified before calling `start()`
         if file == nil {
-            delegate?.dfuError(.fileNotSpecified, didOccurWithMessage: "Firmare not specified")
+            delegate?.dfuError(.fileNotSpecified, didOccurWithMessage: "Firmware not specified")
             return nil
         }
 


### PR DESCRIPTION
The word Firmware is misspelled on line 254