### PR TITLE
DFU no longer takes control over delegates

### DIFF
--- a/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
+++ b/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
@@ -175,7 +175,7 @@ class DFUViewController: UIViewController, CBCentralManagerDelegate, DFUServiceD
         partProgressView.progress = 0.0
 
         // Create DFU initiator with some default configuration
-        let dfuInitiator = DFUServiceInitiator(centralManager: centralManager, target: dfuPeripheral)
+        let dfuInitiator = DFUServiceInitiator(target: dfuPeripheral)
         dfuInitiator.delegate = self
         dfuInitiator.progressDelegate = self
         dfuInitiator.logger = self

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -205,19 +205,30 @@ import CoreBluetooth
     
     /**
      Creates the DFUServiceInitializer that will allow to send an update to the given peripheral.
-     The peripheral should be disconnected prior to calling start() method.
-     The DFU service will automatically connect to the device, check if it has required DFU
-     service (return a delegate callback if does not have such), jump to the DFU Bootloader mode
-     if necessary and perform the DFU. Proper delegate methods will be called during the process.
+     The DFU service will automatically connect to the device, if not connected already,
+     check if it has required DFU service (return a delegate callback if does not have such),
+     jump to the DFU Bootloader mode if necessary, and perform the DFU. Proper delegate methods
+     will be called during the process. The peripheral will not be reconnected after the DFU
+     is completed, aborted or has failed.
      
-     - parameter centralManager: manager that will be used to connect to the peripheral
-     - parameter target: the DFU target peripheral
+     This constructor takes control over the central manager and peripheral objects.
+     Their delegates will be set to internal library objects and will NOT be reverted to
+     original objects, instead they will be set to nil when DFU is complete, aborted or
+     has failed with an error. An app should restore the delegates (if needed) after
+     receiving .completed or .aborted DFUState, or receiving an error.
      
-     - returns: the initiator instance
+     - important: This constructor has been deprecated in favor of `init(target: CBPeripheral)`,
+     which does not take control over the give peripheral, and is using a copy instead.
+     
+     - parameter centralManager: Manager that will be used to connect to the peripheral
+     - parameter target: The DFU target peripheral
+     
+     - returns: The initiator instance
      
      - seeAlso: peripheralSelector property - a selector used when scanning for a device in DFU Bootloader mode
      in case you want to update a Softdevice and Application from a single ZIP Distribution Packet.
      */
+    @available(*, deprecated, message: "Use init(target: CBPeripheral) instead.")
     @objc public init(centralManager: CBCentralManager, target: CBPeripheral) {
         self.centralManager = centralManager
         // Just to be sure that manager is not scanning
@@ -232,12 +243,47 @@ import CoreBluetooth
     }
     
     /**
+     Creates the DFUServiceInitializer that will allow to send an update to the given peripheral.
+     The DFU service will automatically connect to the device, if not connected already,
+     check if it has required DFU service (return a delegate callback if does not have such),
+     jump to the DFU Bootloader mode if necessary, and perform the DFU. Proper delegate methods
+     will be called during the process. The peripheral will NOT be reconnected after the DFU
+     is completed, aborted or has failed.
+     
+     This constructor does not take control over the given peripheral, nor the central manager.
+     A new central manager is used, from which a copy of the peripheral is retrieved. Be warned,
+     that the original peripheral delegate may receive a lot of calls, and will restart during
+     the process. The app should not send any data to DFU characteristics when DFU is in progress.
+     
+     - parameter target: The DFU target peripheral
+     
+     - returns: The initiator instance
+     
+     - version: Added in version 4.2 of the iOS DFU Library.
+     - seeAlso: peripheralSelector property - a selector used when scanning for a device in DFU Bootloader mode
+     in case you want to update a Softdevice and Application from a single ZIP Distribution Packet.
+     */
+    @objc public init(target: CBPeripheral) {
+        // Create a new instance of CBCentralManager
+        self.centralManager = CBCentralManager()
+        // As the given peripheral was obtained using a different central manager,
+        // its new instance must be obtained from the new manager.
+        self.target = self.centralManager.retrievePeripherals(withIdentifiers: [target.identifier]).first!
+        // Default peripheral selector will choose the service UUID as a filter
+        self.peripheralSelector = DFUPeripheralSelector()
+        // Default UUID helper with standard set of UUIDs
+        self.uuidHelper = DFUUuidHelper()
+        
+        super.init()
+    }
+    
+    /**
      Sets the file with the firmware. The file must be specified before calling `start()` method,
      and must not be nil.
      
      - parameter file: The firmware wrapper object
      
-     - returns: the initiator instance to allow chain use
+     - returns: The initiator instance to allow chain use
      */
     @objc public func with(firmware file: DFUFirmware) -> DFUServiceInitiator {
         self.file = file


### PR DESCRIPTION
With this fix, the `CBCentralManager` is no longer needed. The `init(centralManager:target)` method has been deprecated (and will work like before until it gets removed). The new `init(target)` will instead create a new instance of `CBCentralManager`, and will retrieve a copy of `CBPeripheral` from it, based on the `target.identifier`. Original target's delegate remains intact. The lib has now its own set of objects and delegates.