### PR TITLE
Logging services on not supported devices

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -300,7 +300,7 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             } else {
                 logger.d("No services found")
             }
-            logger.d("Is it the right device? If so, it may be caching issue. Try again after restarting Bluetooth. Make sure that your device has the Service Changed characteristic")
+            logger.d("Did you connect to the correct target? It might be that the previous services were cached: toggle Bluetooth from iOS settings to clear cache. Also, ensure the device contains the Service Changed characteristic")
             
             // The device does not support DFU, nor buttonless jump
             delegate?.error(.deviceNotSupported, didOccurWithMessage: "DFU Service not found")

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -290,6 +290,18 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         // Search for DFU service
         guard let dfuService = findDfuService(in: peripheral.services) else {
             logger.e("DFU Service not found")
+            
+            // Log what was found in case of an error
+            if let services = peripheral.services, services.isEmpty == false {
+                logger.d("The following services were discovered:")
+                services.forEach { service in
+                    logger.d(" - \(service.uuid.uuidString)")
+                }
+            } else {
+                logger.d("No services found")
+            }
+            logger.d("Is it the right device? If so, it may be caching issue. Try again after restarting Bluetooth. Make sure that your device has the Service Changed characteristic")
+            
             // The device does not support DFU, nor buttonless jump
             delegate?.error(.deviceNotSupported, didOccurWithMessage: "DFU Service not found")
             return

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -550,69 +550,70 @@ import CoreBluetooth
         self.success = nil
         self.report = nil
         
-        if error != nil {
+        guard error == nil else {
             logger.e("Characteristics discovery failed")
             logger.e(error!)
             _report?(.serviceDiscoveryFailed, "Characteristics discovery failed")
-        } else {
-            logger.i("DFU characteristics discovered")
-            
-            // Find DFU characteristics
-            if let characteristics = service.characteristics {
-                for characteristic in characteristics {
-                    if characteristic.matches(uuid: uuidHelper.legacyDFUPacket) {
-                        dfuPacketCharacteristic = DFUPacket(characteristic, logger)
-                    } else if characteristic.matches(uuid: uuidHelper.legacyDFUControlPoint) {
-                        dfuControlPointCharacteristic = DFUControlPoint(characteristic, logger)
-                    } else if characteristic.matches(uuid: uuidHelper.legacyDFUVersion) {
-                        dfuVersionCharacteristic = DFUVersion(characteristic, logger)
-                    }
+            return
+        }
+
+        logger.i("DFU characteristics discovered")
+        
+        // Find DFU characteristics
+        if let characteristics = service.characteristics {
+            for characteristic in characteristics {
+                if characteristic.matches(uuid: uuidHelper.legacyDFUPacket) {
+                    dfuPacketCharacteristic = DFUPacket(characteristic, logger)
+                } else if characteristic.matches(uuid: uuidHelper.legacyDFUControlPoint) {
+                    dfuControlPointCharacteristic = DFUControlPoint(characteristic, logger)
+                } else if characteristic.matches(uuid: uuidHelper.legacyDFUVersion) {
+                    dfuVersionCharacteristic = DFUVersion(characteristic, logger)
                 }
             }
-            
-            // Log what was found in case of an error
-            if dfuPacketCharacteristic == nil {
-                if let characteristics = service.characteristics, characteristics.isEmpty == false {
-                    logger.d("The following characteristics were found:")
-                    characteristics.forEach { characteristic in
-                        logger.d(" - \(characteristic.uuid.uuidString)")
-                    }
-                } else {
-                    logger.d("No characteristics found in the service")
-                }
-                logger.d("Is it the right device? If so, it may be caching issue. Try again after restarting Bluetooth. Make sure that your device has the Service Changed characteristic")
-            }
-            
-            // Some validation
-            if dfuControlPointCharacteristic == nil {
-                logger.e("DFU Control Point characteristic not found")
-                // DFU Control Point characteristic is required
-                _report?(.deviceNotSupported, "DFU Control Point characteristic not found")
-                return
-            }
-            if !dfuControlPointCharacteristic!.valid {
-                logger.e("DFU Control Point characteristic must have Write and Notify properties")
-                // DFU Control Point characteristic must have Write and Notify properties
-                _report?(.deviceNotSupported, "DFU Control Point characteristic does not have the Write and Notify properties")
-                return
-            }
-            
-            // Note: DFU Packet characteristic is not required in the App mode.
-            //       The mbed implementation of DFU Service doesn't have such.
-            
-            // Read DFU Version characteristic if such exists
-            if self.dfuVersionCharacteristic != nil {
-                if dfuVersionCharacteristic!.valid {
-                    readDfuVersion(onSuccess: _success!, onError: _report!)
-                } else {
-                    version = nil
-                    _report?(.readingVersionFailed, "DFU Version found, but does not have the Read property")
+        }
+        
+        // Log what was found in case of an error
+        if dfuPacketCharacteristic == nil {
+            if let characteristics = service.characteristics, characteristics.isEmpty == false {
+                logger.d("The following characteristics were found:")
+                characteristics.forEach { characteristic in
+                    logger.d(" - \(characteristic.uuid.uuidString)")
                 }
             } else {
-                // Else... proceed
-                version = nil
-                _success?()
+                logger.d("No characteristics found in the service")
             }
+            logger.d("Did you connect to the correct target? It might be that the previous services were cached: toggle Bluetooth from iOS settings to clear cache. Also, ensure the device contains the Service Changed characteristic")
+        }
+        
+        // Some validation
+        guard dfuControlPointCharacteristic != nil else {
+            logger.e("DFU Control Point characteristic not found")
+            // DFU Control Point characteristic is required
+            _report?(.deviceNotSupported, "DFU Control Point characteristic not found")
+            return
+        }
+        guard dfuControlPointCharacteristic!.valid else {
+            logger.e("DFU Control Point characteristic must have Write and Notify properties")
+            // DFU Control Point characteristic must have Write and Notify properties
+            _report?(.deviceNotSupported, "DFU Control Point characteristic does not have the Write and Notify properties")
+            return
+        }
+        
+        // Note: DFU Packet characteristic is not required in the App mode.
+        //       The mbed implementation of DFU Service doesn't have such.
+        
+        // Read DFU Version characteristic if such exists
+        if self.dfuVersionCharacteristic != nil {
+            guard dfuVersionCharacteristic!.valid else {
+                version = nil
+                _report?(.readingVersionFailed, "DFU Version found, but does not have the Read property")
+                return
+            }
+            readDfuVersion(onSuccess: _success!, onError: _report!)
+        } else {
+            // Else... proceed
+            version = nil
+            _success?()
         }
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -394,43 +394,64 @@ import CoreBluetooth
             logger.i("DFU characteristics discovered")
             
             // Find DFU characteristics
-            for characteristic in service.characteristics! {                
-                if characteristic.matches(uuid: uuidHelper.secureDFUPacket) {
-                    dfuPacketCharacteristic = SecureDFUPacket(characteristic, logger)
-                } else if characteristic.matches(uuid: uuidHelper.secureDFUControlPoint) {
-                    dfuControlPointCharacteristic = SecureDFUControlPoint(characteristic, logger)
+            if let characteristics = service.characteristics {
+                for characteristic in characteristics {
+                    if characteristic.matches(uuid: uuidHelper.secureDFUPacket) {
+                        dfuPacketCharacteristic = SecureDFUPacket(characteristic, logger)
+                    } else if characteristic.matches(uuid: uuidHelper.secureDFUControlPoint) {
+                        dfuControlPointCharacteristic = SecureDFUControlPoint(characteristic, logger)
+                    }
+                    // Support for Buttonless DFU Service from SDK 12.x (as experimental).
+                    // SDK 13 added a new characteristic in Secure DFU Service with buttonless
+                    // feature without bond sharing (bootloader uses different device address).
+                    // SDK 14 added a new characteristic with buttonless service for bonded
+                    // devices with bond information sharing between app and the bootloader.
+                    else if uuidHelper.matchesButtonless(characteristic) {
+                        buttonlessDfuCharacteristic = ButtonlessDFU(characteristic, logger)
+                        buttonlessDfuCharacteristic?.uuidHelper = uuidHelper
+                        _success?()
+                        return
+                    }
+                    // End
                 }
-                // Support for Buttonless DFU Service from SDK 12.x (as experimental).
-                // SDK 13 added a new characteristic in Secure DFU Service with buttonless
-                // feature without bond sharing (bootloader uses different device address).
-                // SDK 14 will add a new characteristic with buttonless service for bonded
-                // devices with bond information sharing between app and the bootloader.
-                else if uuidHelper.matchesButtonless(characteristic) {
-                    buttonlessDfuCharacteristic = ButtonlessDFU(characteristic, logger)
-                    buttonlessDfuCharacteristic?.uuidHelper = uuidHelper
-                    _success?()
-                    return
+            }
+            
+            // Log what was found in case of an error
+            if dfuPacketCharacteristic == nil || dfuControlPointCharacteristic == nil {
+                if let characteristics = service.characteristics, characteristics.isEmpty == false {
+                    logger.d("The following characteristics were found:")
+                    characteristics.forEach { characteristic in
+                        logger.d(" - \(characteristic.uuid.uuidString)")
+                    }
+                } else {
+                    logger.d("No characteristics found in the service")
                 }
-                // End
+                logger.d("Is it the right device? If so, it may be caching issue. Try again after restarting Bluetooth. Make sure that your device has the Service Changed characteristic")
             }
             
             // Some validation
             if dfuControlPointCharacteristic == nil {
-                logger.e("DFU Control Point characteristics not found")
+                logger.e("DFU Control Point characteristic not found")
                 // DFU Control Point characteristic is required
                 _report?(.deviceNotSupported, "DFU Control Point characteristic not found")
                 return
             }
             if dfuPacketCharacteristic == nil {
-                logger.e("DFU Packet characteristics not found")
+                logger.e("DFU Packet characteristic not found")
                 // DFU Packet characteristic is required
                 _report?(.deviceNotSupported, "DFU Packet characteristic not found")
                 return
             }
             if !dfuControlPointCharacteristic!.valid {
-                logger.e("DFU Control Point characteristics must have Write and Notify properties")
+                logger.e("DFU Control Point characteristic must have Write and Notify properties")
                 // DFU Control Point characteristic must have Write and Notify properties
                 _report?(.deviceNotSupported, "DFU Control Point characteristic does not have the Write and Notify properties")
+                return
+            }
+            if !dfuPacketCharacteristic!.valid {
+                logger.e("DFU Packet characteristic must have Write Without Response property")
+                // DFU Packet characteristic must have Write Without Response property
+                _report?(.deviceNotSupported, "DFU Packet characteristic must have Write Without Response property")
                 return
             }
             

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -386,77 +386,78 @@ import CoreBluetooth
         self.success = nil
         self.report  = nil
         
-        if error != nil {
+        guard error == nil else {
             logger.e("Characteristics discovery failed")
             logger.e(error!)
             _report?(.serviceDiscoveryFailed, "Characteristics discovery failed")
-        } else {
-            logger.i("DFU characteristics discovered")
-            
-            // Find DFU characteristics
-            if let characteristics = service.characteristics {
-                for characteristic in characteristics {
-                    if characteristic.matches(uuid: uuidHelper.secureDFUPacket) {
-                        dfuPacketCharacteristic = SecureDFUPacket(characteristic, logger)
-                    } else if characteristic.matches(uuid: uuidHelper.secureDFUControlPoint) {
-                        dfuControlPointCharacteristic = SecureDFUControlPoint(characteristic, logger)
-                    }
-                    // Support for Buttonless DFU Service from SDK 12.x (as experimental).
-                    // SDK 13 added a new characteristic in Secure DFU Service with buttonless
-                    // feature without bond sharing (bootloader uses different device address).
-                    // SDK 14 added a new characteristic with buttonless service for bonded
-                    // devices with bond information sharing between app and the bootloader.
-                    else if uuidHelper.matchesButtonless(characteristic) {
-                        buttonlessDfuCharacteristic = ButtonlessDFU(characteristic, logger)
-                        buttonlessDfuCharacteristic?.uuidHelper = uuidHelper
-                        _success?()
-                        return
-                    }
-                    // End
-                }
-            }
-            
-            // Log what was found in case of an error
-            if dfuPacketCharacteristic == nil || dfuControlPointCharacteristic == nil {
-                if let characteristics = service.characteristics, characteristics.isEmpty == false {
-                    logger.d("The following characteristics were found:")
-                    characteristics.forEach { characteristic in
-                        logger.d(" - \(characteristic.uuid.uuidString)")
-                    }
-                } else {
-                    logger.d("No characteristics found in the service")
-                }
-                logger.d("Is it the right device? If so, it may be caching issue. Try again after restarting Bluetooth. Make sure that your device has the Service Changed characteristic")
-            }
-            
-            // Some validation
-            if dfuControlPointCharacteristic == nil {
-                logger.e("DFU Control Point characteristic not found")
-                // DFU Control Point characteristic is required
-                _report?(.deviceNotSupported, "DFU Control Point characteristic not found")
-                return
-            }
-            if dfuPacketCharacteristic == nil {
-                logger.e("DFU Packet characteristic not found")
-                // DFU Packet characteristic is required
-                _report?(.deviceNotSupported, "DFU Packet characteristic not found")
-                return
-            }
-            if !dfuControlPointCharacteristic!.valid {
-                logger.e("DFU Control Point characteristic must have Write and Notify properties")
-                // DFU Control Point characteristic must have Write and Notify properties
-                _report?(.deviceNotSupported, "DFU Control Point characteristic does not have the Write and Notify properties")
-                return
-            }
-            if !dfuPacketCharacteristic!.valid {
-                logger.e("DFU Packet characteristic must have Write Without Response property")
-                // DFU Packet characteristic must have Write Without Response property
-                _report?(.deviceNotSupported, "DFU Packet characteristic must have Write Without Response property")
-                return
-            }
-            
-            _success?()
+            return
         }
+
+        logger.i("DFU characteristics discovered")
+        
+        // Find DFU characteristics
+        if let characteristics = service.characteristics {
+            for characteristic in characteristics {
+                if characteristic.matches(uuid: uuidHelper.secureDFUPacket) {
+                    dfuPacketCharacteristic = SecureDFUPacket(characteristic, logger)
+                } else if characteristic.matches(uuid: uuidHelper.secureDFUControlPoint) {
+                    dfuControlPointCharacteristic = SecureDFUControlPoint(characteristic, logger)
+                }
+                // Support for Buttonless DFU Service from SDK 12.x (as experimental).
+                // SDK 13 added a new characteristic in Secure DFU Service with buttonless
+                // feature without bond sharing (bootloader uses different device address).
+                // SDK 14 added a new characteristic with buttonless service for bonded
+                // devices with bond information sharing between app and the bootloader.
+                else if uuidHelper.matchesButtonless(characteristic) {
+                    buttonlessDfuCharacteristic = ButtonlessDFU(characteristic, logger)
+                    buttonlessDfuCharacteristic?.uuidHelper = uuidHelper
+                    _success?()
+                    return
+                }
+                // End
+            }
+        }
+        
+        // Log what was found in case of an error
+        if dfuPacketCharacteristic == nil || dfuControlPointCharacteristic == nil {
+            if let characteristics = service.characteristics, characteristics.isEmpty == false {
+                logger.d("The following characteristics were found:")
+                characteristics.forEach { characteristic in
+                    logger.d(" - \(characteristic.uuid.uuidString)")
+                }
+            } else {
+                logger.d("No characteristics found in the service")
+            }
+            logger.d("Did you connect to the correct target? It might be that the previous services were cached: toggle Bluetooth from iOS settings to clear cache. Also, ensure the device contains the Service Changed characteristic")
+        }
+        
+        // Some validation
+        guard dfuControlPointCharacteristic != nil else {
+            logger.e("DFU Control Point characteristic not found")
+            // DFU Control Point characteristic is required
+            _report?(.deviceNotSupported, "DFU Control Point characteristic not found")
+            return
+        }
+        guard dfuPacketCharacteristic != nil else {
+            logger.e("DFU Packet characteristic not found")
+            // DFU Packet characteristic is required
+            _report?(.deviceNotSupported, "DFU Packet characteristic not found")
+            return
+        }
+        guard dfuControlPointCharacteristic!.valid else {
+            logger.e("DFU Control Point characteristic must have Write and Notify properties")
+            // DFU Control Point characteristic must have Write and Notify properties
+            _report?(.deviceNotSupported, "DFU Control Point characteristic does not have the Write and Notify properties")
+            return
+        }
+        guard dfuPacketCharacteristic!.valid else {
+            logger.e("DFU Packet characteristic must have Write Without Response property")
+            // DFU Packet characteristic must have Write Without Response property
+            _report?(.deviceNotSupported, "DFU Packet characteristic must have Write Without Response property")
+            return
+        }
+        
+        _success?()
     }
     
     // MARK: - Support for Buttonless DFU Service


### PR DESCRIPTION
Related to #226. This PR adds logging of services when DFU service or characteristics were not found. The log will list available services/characteristics and will suggest a solution.