### PR TITLE
Bugfix/245

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -191,7 +191,10 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         
         dfuService!.sendActivateAndResetRequest(
             // onSuccess the device gets disconnected and centralManager(_:didDisconnectPeripheral:error) will be called
-            onError: defaultErrorCallback
+            onError: { (error, message) in
+                self.activating = false
+                self.delegate?.error(error, didOccurWithMessage: message)
+            }
         )
     }
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -189,11 +189,14 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      and the device will disconnect on its own on Execute command. Delegate's onTransferComplete event will be called when
      the disconnect event is receviced.
      */
-    func sendExecuteCommand(andActivateIf activating: Bool = false) {
-        self.activating = activating
+    func sendExecuteCommand(andActivateIf complete: Bool = false) {
+        activating = complete
         dfuService!.executeCommand(
             onSuccess: { self.delegate?.peripheralDidExecuteObject() },
-            onError: defaultErrorCallback
+            onError: { (error, message) in
+                self.activating = false
+                self.delegate?.error(error, didOccurWithMessage: message)
+            }
         )
     }
 }


### PR DESCRIPTION
This should fix #245. The reason the error wasn't reported to the app was the *activating* flag, that was set prior to sending the Execute command, but not reset when the Execute failed. Then, in [here](https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift#L531) it was reporting state Completed without checking if delegate.error was set. With this flag cleared properly, it won't go to into this if, and will call `super.peripheralDidDisconnect()` which will check for the error.