### PR TITLE
Added option to disable resuming of a dfu operation

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -201,6 +201,11 @@ import CoreBluetooth
     */
     @objc public var uuidHelper: DFUUuidHelper
 
+    /**
+     Disable the ability for the DFU process to resume from where it was.
+    */
+    @objc public var disableResume: Bool = false
+
     //MARK: - Public API
     
     /**

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -96,8 +96,8 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         
         // Was Init packet sent, at least partially, before?
         if offset > 0 {
-            // Verify CRC of the part that was sent before
-            if verifyCRC(for: firmware.initPacket!, andPacketOffset: offset, matches: crc) {
+            // If we are allowed to resume, then verify CRC of the part that was sent before
+            if !initiator.disableResume && verifyCRC(for: firmware.initPacket!, andPacketOffset: offset, matches: crc) {
                 // Resume sending Init Packet
                 if offset < UInt32(firmware.initPacket!.count) {
                     logWith(.application, message: "Resuming sending Init packet...")


### PR DESCRIPTION
This adds a 'disableResume' option, like the android library has, if you wish to not resume a dfu operation from where it was.