### PR TITLE
Removing name conflict in the library

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -140,7 +140,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
     }
     
     func peripheralDidReceiveInitPacket() {
-        logger.a(String(format: "Command object sent (CRC = %08X)", CRC32(data: firmware.initPacket!).crc))
+        logger.a(String(format: "Command object sent (CRC = %08X)", crc32(data: firmware.initPacket!)))
         
         // Init Packet sent. Let's check the CRC before executing it.
         peripheral.sendCalculateChecksumCommand() // -> peripheralDidSendChecksum(...) will be called
@@ -371,7 +371,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         }
         // Get data form 0 up to the offset the peripheral has reproted
         let offsetData : Data = (data.subdata(in: 0 ..< Int(offset)))
-        let calculatedCRC = CRC32(data: offsetData).crc
+        let calculatedCRC = crc32(data: offsetData)
         
         // This returns true if the current data packet's CRC matches the current firmware's packet CRC
         return calculatedCRC == crc

--- a/iOSDFULibrary/Classes/Utilities/crc32.swift
+++ b/iOSDFULibrary/Classes/Utilities/crc32.swift
@@ -84,6 +84,19 @@ private let crcTable: [UInt32] = [
     0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b,
     0x2d02ef8d]
 
+/// Calculates CRC32 value from the given Data.
+///
+/// - parameter data: Data to calculate CRC from.
+/// - returns: The CRC32 calculated over the whole Data object.
+func crc32(data: Data?) -> UInt32 {
+    return crc32(0, data: data)
+}
+
+/// Updates the running crc with the bytes from given Data.
+///
+/// - parameter crc:  The crc to be updated.
+/// - parameter data: Data to calculate CRC from.
+/// - returns: The CRC32 updated using whole Data object.
 func crc32(_ crc: UInt32, data: Data?) -> UInt32 {
     guard let data = data else {
         return crc32(0, buffer: nil, length: 0)
@@ -134,11 +147,12 @@ func crc32(_ crc: UInt32, buffer: UnsafePointer<UInt8>?, length: Int) -> UInt32 
     return crc1 ^ 0xffffffff;
 }
 
-func ==(lhs: CRC32, rhs: CRC32) -> Bool {
+/*
+func ==(lhs: CRC32Calculator, rhs: CRC32Calculator) -> Bool {
     return lhs.initialized == rhs.initialized && lhs.crc == rhs.crc
 }
 
-final class CRC32: Hashable {
+final class CRC32Calculator: Hashable {
     fileprivate var initialized = false
     fileprivate(set) var crc: UInt32 = 0
     
@@ -163,4 +177,4 @@ final class CRC32: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(crc)
     }
-}
+}*/


### PR DESCRIPTION
This PR fixes #283 by removing the CRC32 class. Instead the `crc32(data:)` method will be used.