### PR TITLE
Allow user to specify an alternative advertising name

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -162,6 +162,12 @@ import CoreBluetooth
      For more information read: https://github.com/NordicSemiconductor/IOS-nRF-Connect/issues/16
      */
     @objc public var alternativeAdvertisingNameEnabled = true
+
+    /**
+     If `alternativeAdvertisingNameEnabled` is `true` then this specifies the alternative name to use. If nil (default)
+     then a random name is generated.
+     */
+    @objc public var alternativeAdvertisingName: String? = nil
     
     /**
      Set this flag to true to enable experimental buttonless feature in Secure DFU. When the 

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -507,17 +507,14 @@ import CoreBluetooth
      
      - parameter report: Method called when an error occurred.
      */
-    func jumpToBootloaderMode(withAlternativeAdvertisingName rename: Bool, onError report: @escaping ErrorCallback) {
+    func jumpToBootloaderMode(withAlternativeAdvertisingName name: String?, onError report: @escaping ErrorCallback) {
         if !aborted {
             func enterBootloader() {
                 self.buttonlessDfuCharacteristic!.send(ButtonlessDFURequest.enterBootloader, onSuccess: nil, onError: report)
             }
             
             // If the device may support setting alternative advertising name in the bootloader mode, try it
-            if rename && buttonlessDfuCharacteristic!.maySupportSettingName {
-                // Generate a random 8-character long name
-                let name = String(format: "Dfu%05d", arc4random_uniform(100000))
-                
+            if let name = name, buttonlessDfuCharacteristic!.maySupportSettingName {
                 logger.v("Trying setting bootloader name to \(name)")
                 buttonlessDfuCharacteristic!.send(ButtonlessDFURequest.set(name: name), onSuccess: {
                     // Success. The buttonless service is from SDK 14.0+. The bootloader, after jumping to it, will advertise with this name.


### PR DESCRIPTION
Allows DFU library users to specify the alternative advertisement name to use, or if `nil` (default) then it generates a random name.

Closes #278.