### PR TITLE
Bugfix for iOS 13

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -991,7 +991,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1030;
 				TargetAttributes = {
 					9AF8AE8821E967844EEF26BBB341564D = {
 						LastSwiftMigration = 1020;
@@ -1327,7 +1327,6 @@
 			baseConfigurationReference = 2C723040DECD495E1AAC81F5AA497C97 /* Pods-macOSDFULibrary_Example.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1362,7 +1361,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6CCC32CD1F9DE588C70537578CFC9DB9 /* iOSDFULibrary-macOS.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1429,7 +1427,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7D90563942E115795A1F5E9E6C7A0D26 /* ZIPFoundation-macOS.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1464,7 +1461,6 @@
 			baseConfigurationReference = 890A09B61D0F51EA84B75D5E02FE58D2 /* Pods-macOSDFULibrary_Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1499,7 +1495,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6CCC32CD1F9DE588C70537578CFC9DB9 /* iOSDFULibrary-macOS.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1752,7 +1747,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7D90563942E115795A1F5E9E6C7A0D26 /* ZIPFoundation-macOS.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Zip-iOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Zip-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Zip-macOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Zip-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-iOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6C62C12CF3E12DC4C73C47D64E9A13BA"
+               BlueprintIdentifier = "D5D94E351BD6926C6DC33FBD834E16AC"
                BuildableName = "iOSDFULibrary.framework"
                BlueprintName = "iOSDFULibrary-iOS"
                ReferencedContainer = "container:Pods.xcodeproj">
@@ -45,7 +45,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6C62C12CF3E12DC4C73C47D64E9A13BA"
+            BlueprintIdentifier = "D5D94E351BD6926C6DC33FBD834E16AC"
             BuildableName = "iOSDFULibrary.framework"
             BlueprintName = "iOSDFULibrary-iOS"
             ReferencedContainer = "container:Pods.xcodeproj">

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-macOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B80353FE3CEF70529DB8DB81E67C1C39"
+               BlueprintIdentifier = "79F9638EA00F4594D84B597FE45CD2DC"
                BuildableName = "iOSDFULibrary.framework"
                BlueprintName = "iOSDFULibrary-macOS"
                ReferencedContainer = "container:Pods.xcodeproj">
@@ -45,7 +45,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B80353FE3CEF70529DB8DB81E67C1C39"
+            BlueprintIdentifier = "79F9638EA00F4594D84B597FE45CD2DC"
             BuildableName = "iOSDFULibrary.framework"
             BlueprintName = "iOSDFULibrary-macOS"
             ReferencedContainer = "container:Pods.xcodeproj">

--- a/Example/iOSDFULibrary.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-Example.xcscheme
+++ b/Example/iOSDFULibrary.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -50,6 +50,7 @@ internal protocol BaseDFUPeripheralAPI : class, DFUController {
 internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDFUPeripheralAPI, CBPeripheralDelegate, CBCentralManagerDelegate {
     /// Bluetooth Central Manager used to scan for the peripheral.
     internal let centralManager: CBCentralManager
+    internal let targetIdentifier: UUID
     internal let queue: DispatchQueue
     /// The DFU Target peripheral.
     internal var peripheral: CBPeripheral?
@@ -89,14 +90,13 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     
     init(_ initiator: DFUServiceInitiator, _ logger: LoggerHelper) {
         self.centralManager = initiator.centralManager
+        self.targetIdentifier = initiator.targetIdentifier
         self.queue = initiator.queue
         self.logger = logger
         self.experimentalButtonlessServiceInSecureDfuEnabled = initiator.enableUnsafeExperimentalButtonlessServiceInSecureDfu
         self.uuidHelper = initiator.uuidHelper
 
         super.init()
-        // Set the initial peripheral. It may be changed later (flashing App fw after first flashing SD/BL)
-        self.peripheral = initiator.target
     }
     
     // MARK: - Base DFU Peripheral API
@@ -109,14 +109,20 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             // Central manager not ready. Wait for poweredOn state.
             return
         }
+        // Set the initial peripheral. It may be changed later (flashing App fw after first flashing SD/BL).
+        guard let peripheral = centralManager.retrievePeripherals(withIdentifiers: [targetIdentifier]).first else {
+            delegate?.error(.bluetoothDisabled, didOccurWithMessage: "Could not obtain peripheral instance")
+            return
+        }
+        self.peripheral = peripheral
         
-        if peripheral!.state != .connected {
+        if peripheral.state != .connected {
             connect()
         } else {
-            let name = peripheral!.name ?? "Unknown device"
+            let name = peripheral.name ?? "Unknown device"
             logger.i("Connected to \(name)")
             
-            let dfuService = findDfuService(in: peripheral!.services)
+            let dfuService = findDfuService(in: peripheral.services)
             if dfuService == nil {
                 // DFU service has not been found, but it doesn't matter it's not there.
                 // Perhaps the user's application didn't discover it. Let's discover DFU services.


### PR DESCRIPTION
This PR fixes #322, the issue on iOS 13 when `CBCentralManager.retrievePeripherals(withIdentifiers:)` no longer works when the manager is not in `.poweredOn` state. Retrieving was moved to inside `BaseDFUPeripheral`, when we are sure the manager is ready.

Also, this PR sets some Xcode 10.3 constants.