### PR TITLE
Fix a potential crash of Xcode when using SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(
-      url: "https://github.com/weichsel/ZIPFoundation/",
+      url: "https://github.com/weichsel/ZIPFoundation",
       .exact("0.9.9")
     )
   ],

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let package = Package(
   name: "<Your Product Name>",
   dependencies: [
     .package(
-      url: "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/", 
+      url: "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library", 
       .upToNextMajor(from: "4.6.1")
     )
   ],


### PR DESCRIPTION
Xcode 11.3.1 goes nuts if you include `/` at the end of the dependency URL. Obviously this is an Xcode bug, but it doesn't hurt to prevent that in the manifest configuration and the documentation.

The crash is a little bit random but reproducible when you import THIS library and `Reset Package Caches` multiple times. Not only will it crash, the package resolution will produce `ZIPFoundation 4.6.1` which is already an indication that something is off as it should be `NordicDFU 4.6.1`.


