### PR TITLE
Fix pointer use

### DIFF
--- a/iOSDFULibrary/Classes/Utilities/Data.swift
+++ b/iOSDFULibrary/Classes/Utilities/Data.swift
@@ -88,7 +88,9 @@ extension DataConvertible {
     
     public static func + (lhs: Data, rhs: Self) -> Data {
         var value = rhs
-        let data = Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+        let data = withUnsafePointer(to: &value) { (pointer) -> Data in
+            Data(buffer: UnsafeBufferPointer(start: pointer, count: 1))
+        }
         return lhs + data
     }
     


### PR DESCRIPTION
The previous use resulted in the warning "Initialization of 'UnsafeBufferPointer<Self>' results in a dangling buffer pointer", because the reference to value is only valid for the duration of the call to `UnsafeBufferPointer`. `withUnsafePointer` must be used to create a pointer which is also valid for the `Data` initialization.