### PR TITLE
Report error when bluetooth is turned off.

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -116,14 +116,17 @@ extension BaseDFUExecutor {
     }
     
     func error(_ error: DFUError, didOccurWithMessage message: String) {
+        if error == .bluetoothDisabled {
+            delegate{ $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message) }
+            // Release the cyclic reference.
+            peripheral.destroy()
+            return
+        }
+        
         // Save the error. It will be reported when the device disconnects.
         if self.error == nil {
             self.error = (error, message)
             peripheral.resetDevice()
-        }
-        
-        if error == .bluetoothDisabled {
-            delegate{ $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message) }
         }
     }
     

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -121,6 +121,10 @@ extension BaseDFUExecutor {
             self.error = (error, message)
             peripheral.resetDevice()
         }
+        
+        if error == .bluetoothDisabled {
+            delegate{ $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message) }
+        }
     }
     
     // MARK: - Helper functions


### PR DESCRIPTION
We are using the DFU library, but our testers found out that when in the middle of ota if user turns bluetooth off the process gets stuck and nothing is reported from the library to the client.
We added this line to report the error to the client when bluetooth is turned off. When bluetooth is turned off the error is reported to the client and the cyclic reference is released. Then in the client is responsible to prompt the user to turn off bluetooth again and restart the ota process.
