### PR TITLE
Option to force scan for new address in Legacy DFU

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -169,6 +169,21 @@ import CoreBluetooth
     @objc public var forceDfu = false
     
     /**
+     By default, the Legacy DFU bootloader starting from SDK 7.1, when enabled using
+     buttonless service, advertises with the same Bluetooth address as the application
+     using direct advertisement. This complies with the Bluetooth specification.
+     However, starting from iOS 13.x, iPhones and iPads use random addresses on each
+     connection and the direct advertising misses, do not report direct advertisements
+     from non-bonded devices, making reconnection to the bootloader and proceeding
+     with DFU impossible.
+     A solution requires modifying the application not to share the peer data with bootloader,
+     in which case it will advertise undirectly using address +1, like it does when the switch
+     to bootloader mode is initiated with a button. After such modification, setting this
+     flag to true will make the library scan for the bootloader using `DFUPeripheralSelector`.
+     */
+    @objc public var forceScanningForNewAddressInLegacyDfu = false
+    
+    /**
      In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded
      devices which allows to send a unique name to the device before it is switched
      to bootloader mode. After jump, the bootloader will advertise with this name

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -184,6 +184,16 @@ import CoreBluetooth
     @objc public var forceScanningForNewAddressInLegacyDfu = false
     
     /**
+     Connection timeout.
+     
+     When the DFU target does not connect before the time runs out, a timeout error
+     is reported.
+     
+     - since: 4.8.0
+     */
+    @objc public var connectionTimeout: TimeInterval = 10.0
+    
+    /**
      In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded
      devices which allows to send a unique name to the device before it is switched
      to bootloader mode. After jump, the bootloader will advertise with this name

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -173,13 +173,20 @@ import CoreBluetooth
      buttonless service, advertises with the same Bluetooth address as the application
      using direct advertisement. This complies with the Bluetooth specification.
      However, starting from iOS 13.x, iPhones and iPads use random addresses on each
-     connection and the direct advertising misses, do not report direct advertisements
-     from non-bonded devices, making reconnection to the bootloader and proceeding
-     with DFU impossible.
-     A solution requires modifying the application not to share the peer data with bootloader,
-     in which case it will advertise undirectly using address +1, like it does when the switch
-     to bootloader mode is initiated with a button. After such modification, setting this
-     flag to true will make the library scan for the bootloader using `DFUPeripheralSelector`.
+     connection and do not expect direct advertising unless bonded. This causes thiose
+     packets being missed and not reported to the library, making reconnection to the
+     bootloader and proceeding with DFU impossible.
+     A solution requires modifying either the bootloader not to use the direct advertising,
+     or the application not to share the peer data with bootloader, in which case it will
+     advertise undirectly using address +1, like it does when the switch to bootloader mode
+     is initiated with a button. After such modification, setting this flag to true will make the
+     library scan for the bootloader using `DFUPeripheralSelector`.
+     
+     Setting this flag to true without modifying the booloader behavior will break the DFU,
+     as the direct advertising packets are empty and will not pass the default
+     `DFUPeripheralSelector`.
+     
+     - since: 4.8.0
      */
     @objc public var forceScanningForNewAddressInLegacyDfu = false
     

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
@@ -81,7 +81,9 @@ internal class LegacyDFUExecutor : DFUExecutor, LegacyDFUPeripheralDelegate {
             delegate {
                 $0.dfuStateDidChange(to: .enablingDfuMode)
             }
-            peripheral.jumpToBootloader()
+            peripheral.jumpToBootloader(
+                forceNewAddress: initiator.forceScanningForNewAddressInLegacyDfu
+            )
         } else {
             // The device is ready to proceed with DFU.
             peripheral.sendStartDfu(withFirmwareType: firmware.currentPartType,

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -77,10 +77,13 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
     
     /**
      Switches target device to the DFU Bootloader mode.
+     
+     - parameter forceNewAddress: Set to true if the bootloader is expected to adveritse
+                                  with a different address than when in app mode.
      */
-    func jumpToBootloader() {
+    func jumpToBootloader(forceNewAddress: Bool) {
         jumpingToBootloader = true
-        newAddressExpected = dfuService!.newAddressExpected
+        newAddressExpected = dfuService!.newAddressExpected || forceNewAddress
         dfuService!.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.


### PR DESCRIPTION
This PR attempts to allow a workaround for #368. In case legacy DFU fails on newer iOS versions, an update for the app or bootloader is required. The bootloader should not use direct advertising when in bootloader mode. This can be achieved either by modifying the bootloader code, or by not sharing peer data from the app, causing it to use address +1 instead. But the device must be updated using either an older version of iOS, Android or with the bootloader started with a button.
Only after that, setting this new `forceScanningForNewAddressInLegacyDfu` flag to *true* will help on new iOS/Android versions.