### PR TITLE
Version 4.8.0

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1353,6 +1353,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 4.8.0;
 				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS.modulemap";
 				PRODUCT_MODULE_NAME = iOSDFULibrary;
 				PRODUCT_NAME = iOSDFULibrary;
@@ -1383,6 +1384,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 4.8.0;
 				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS.modulemap";
 				PRODUCT_MODULE_NAME = iOSDFULibrary;
 				PRODUCT_NAME = iOSDFULibrary;
@@ -1550,6 +1552,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MARKETING_VERSION = 4.8.0;
 				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS.modulemap";
 				PRODUCT_MODULE_NAME = iOSDFULibrary;
 				PRODUCT_NAME = iOSDFULibrary;
@@ -1741,6 +1744,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 4.8.0;
 				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS.modulemap";
 				PRODUCT_MODULE_NAME = iOSDFULibrary;
 				PRODUCT_NAME = iOSDFULibrary;

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Pods/Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist
+++ b/Example/Pods/Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>4.7.2</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist
+++ b/Example/Pods/Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>4.7.2</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
+++ b/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
@@ -191,6 +191,15 @@ class DFUViewController: UIViewController, CBCentralManagerDelegate, DFUServiceD
         dfuInitiator.delegate = self
         dfuInitiator.progressDelegate = self
         dfuInitiator.logger = self
+        dfuInitiator.dataObjectPreparationDelay = 0.4 // sec
+        
+        // Uncomment if you don't want resume feature in Secure DFU.
+        // See: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/pull/264
+        // dfuInitiator.disableResume = true
+        
+        // Uncomment only if Legacy DFU is us using address+1 in bootloader mode.
+        // See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/262#issuecomment-665493850
+        // dfuInitiator.forceScanningForNewAddressInLegacyDfu = true
 
         // Here would be a good chance to change the UUIDs to your custom UUIDs
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library", 
-      .upToNextMajor(from: "<Desired Version, e.g. 4.7.2>")
+      .upToNextMajor(from: "<Desired Version, e.g. 4.8.0>")
     )
   ],
   targets: [.target(name: "<Your Target Name>", dependencies: ["NordicDFU"])]

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 ### Changelog
+- **4.8.0**
+   - Feature: Option to force scanning for Legacy DFU bootloader after jumping using Buttonless Service (#374).
+   - Feature: Option to set connection timeout (#369).
+   - Feature: Option to set data object preparation delay (#377).
+   
 - **4.7.2**
    - Improvement: Report error when bluetooth is turned off (#371).
    - Bugfix: Fixed Carthage configuration (shared schemes) (#370).

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
-  s.version          = "4.7.2"
+  s.version          = "4.8.0"
   s.summary          = "This repository contains a tested library for iOS 9+ devices to perform Device Firmware Update on the nRF5x devices"
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -300,6 +300,8 @@ import CoreBluetooth
 
     /**
      Disable the ability for the DFU process to resume from where it was.
+     
+     - since: 4.3.0
     */
     @objc public var disableResume: Bool = false
 

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -201,6 +201,31 @@ import CoreBluetooth
     @objc public var connectionTimeout: TimeInterval = 10.0
     
     /**
+     Duration of a delay, that the service will wait before sending each data object in
+     Secure DFU. The delay will be done after a data object is created, and before
+     any data byte is sent. The default value is 0, which disables this feature for the
+     second and following data objects, but the first one will be delayed by 0.4 sec.
+     
+     It has been found, that a delay of at least 0.3 sec reduces the risk of packet lose
+     (the bootloader needs some time to prepare flash memory) on DFU bootloader from
+     SDK 15, 16 and 17. The delay does not have to be longer than 0.4 sec, as according to
+     performed tests, such delay is sufficient.
+     
+     The longer the delay, the more time DFU will take to complete (delay will be repeated for
+     each data object (4096 bytes)). However, with too small delay a packet lose may occur,
+     causing the service to enable PRN and set them to 1 making DFU process very, very slow
+     (but reliable).
+     
+     The recommended delay is from 0.3 to 0.4 second if your DFU bootloader is from
+     SDK 15, 16 or 17. Older bootloaders do not need this delay.
+     
+     This variable is ignored in Legacy DFU.
+     
+     - since: 4.8.0
+     */
+    @objc public var dataObjectPreparationDelay: TimeInterval = 0.0
+    
+    /**
      In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded
      devices which allows to send a unique name to the device before it is switched
      to bootloader mode. After jump, the bootloader will advertise with this name

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -169,6 +169,21 @@ import CoreBluetooth
     @objc public var forceDfu = false
     
     /**
+     By default, the Legacy DFU bootloader starting from SDK 7.1, when enabled using
+     buttonless service, advertises with the same Bluetooth address as the application
+     using direct advertisement. This complies with the Bluetooth specification.
+     However, starting from iOS 13.x, iPhones and iPads use random addresses on each
+     connection and the direct advertising misses, do not report direct advertisements
+     from non-bonded devices, making reconnection to the bootloader and proceeding
+     with DFU impossible.
+     A solution requires modifying the application not to share the peer data with bootloader,
+     in which case it will advertise undirectly using address +1, like it does when the switch
+     to bootloader mode is initiated with a button. After such modification, setting this
+     flag to true will make the library scan for the bootloader using `DFUPeripheralSelector`.
+     */
+    @objc public var forceScanningForNewAddressInLegacyDfu = false
+    
+    /**
      In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded
      devices which allows to send a unique name to the device before it is switched
      to bootloader mode. After jump, the bootloader will advertise with this name

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -184,6 +184,16 @@ import CoreBluetooth
     @objc public var forceScanningForNewAddressInLegacyDfu = false
     
     /**
+     Connection timeout.
+     
+     When the DFU target does not connect before the time runs out, a timeout error
+     is reported.
+     
+     - since: 4.8.0
+     */
+    @objc public var connectionTimeout: TimeInterval = 10.0
+    
+    /**
      In SDK 14.0.0 a new feature was added to the Buttonless DFU for non-bonded
      devices which allows to send a unique name to the device before it is switched
      to bootloader mode. After jump, the bootloader will advertise with this name

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -173,13 +173,20 @@ import CoreBluetooth
      buttonless service, advertises with the same Bluetooth address as the application
      using direct advertisement. This complies with the Bluetooth specification.
      However, starting from iOS 13.x, iPhones and iPads use random addresses on each
-     connection and the direct advertising misses, do not report direct advertisements
-     from non-bonded devices, making reconnection to the bootloader and proceeding
-     with DFU impossible.
-     A solution requires modifying the application not to share the peer data with bootloader,
-     in which case it will advertise undirectly using address +1, like it does when the switch
-     to bootloader mode is initiated with a button. After such modification, setting this
-     flag to true will make the library scan for the bootloader using `DFUPeripheralSelector`.
+     connection and do not expect direct advertising unless bonded. This causes thiose
+     packets being missed and not reported to the library, making reconnection to the
+     bootloader and proceeding with DFU impossible.
+     A solution requires modifying either the bootloader not to use the direct advertising,
+     or the application not to share the peer data with bootloader, in which case it will
+     advertise undirectly using address +1, like it does when the switch to bootloader mode
+     is initiated with a button. After such modification, setting this flag to true will make the
+     library scan for the bootloader using `DFUPeripheralSelector`.
+     
+     Setting this flag to true without modifying the booloader behavior will break the DFU,
+     as the direct advertising packets are empty and will not pass the default
+     `DFUPeripheralSelector`.
+     
+     - since: 4.8.0
      */
     @objc public var forceScanningForNewAddressInLegacyDfu = false
     

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
@@ -81,7 +81,9 @@ internal class LegacyDFUExecutor : DFUExecutor, LegacyDFUPeripheralDelegate {
             delegate {
                 $0.dfuStateDidChange(to: .enablingDfuMode)
             }
-            peripheral.jumpToBootloader()
+            peripheral.jumpToBootloader(
+                forceNewAddress: initiator.forceScanningForNewAddressInLegacyDfu
+            )
         } else {
             // The device is ready to proceed with DFU.
             peripheral.sendStartDfu(withFirmwareType: firmware.currentPartType,

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -77,10 +77,13 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
     
     /**
      Switches target device to the DFU Bootloader mode.
+     
+     - parameter forceNewAddress: Set to true if the bootloader is expected to adveritse
+                                  with a different address than when in app mode.
      */
-    func jumpToBootloader() {
+    func jumpToBootloader(forceNewAddress: Bool) {
         jumpingToBootloader = true
-        newAddressExpected = dfuService!.newAddressExpected
+        newAddressExpected = dfuService!.newAddressExpected || forceNewAddress
         dfuService!.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -317,9 +317,10 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         logger.i("Data object \(currentRangeIdx + 1)/\(firmwareRanges!.count) created")
         // For SDK 15.x and 16 the bootloader needs some time before it's ready to receive data.
         // Otherwise, some packets may be discarded and the received checksum will not match.
-        if currentRangeIdx == 0 {
-            logger.d("wait(400)")
-            initiator.queue.asyncAfter(deadline: .now() + .milliseconds(400)) {
+        if currentRangeIdx == 0 || initiator.dataObjectPreparationDelay > 0 {
+            let delay = initiator.dataObjectPreparationDelay > 0 ? initiator.dataObjectPreparationDelay : 0.4
+            logger.d("wait(\(Int(delay * 1000))")
+            initiator.queue.asyncAfter(deadline: .now() + delay) {
                 self.sendDataObject(self.currentRangeIdx) // -> peripheralDidReceiveObject() will be called.
             }
         } else {


### PR DESCRIPTION
This version adds the following features:
1. Option to force scan for DFU bootloaders advertising with address + 1 (#374). See https://github.com/NordicSemiconductor/Android-DFU-Library/issues/262#issuecomment-665493850 for reference.
2. Option to set connection timeout #369.
3. Option to set data object preparation delay (#377). 