### PR TITLE
Reconnection improvements

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -319,7 +319,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         // Otherwise, some packets may be discarded and the received checksum will not match.
         if currentRangeIdx == 0 || initiator.dataObjectPreparationDelay > 0 {
             let delay = initiator.dataObjectPreparationDelay > 0 ? initiator.dataObjectPreparationDelay : 0.4
-            logger.d("wait(\(Int(delay * 1000))")
+            logger.d("wait(\(Int(delay * 1000)))")
             initiator.queue.asyncAfter(deadline: .now() + delay) {
                 self.sendDataObject(self.currentRangeIdx) // -> peripheralDidReceiveObject() will be called.
             }


### PR DESCRIPTION
This PR adds the following improvements:
- Scanning now uses the same `connectionTimeout` as connection. Before, there was no timeout when jumping to bootloader mode, and the DFU process might have never finished when the bootloader failed to start. Now, the `.failedToConnect` error will be reported instead.
- When working with Legacy DFU devices, that may or may not advertise with address + 1, and after setting `DFUServiceInitiator. forceScanningForNewAddressInLegacyDfu` to *true*, the library will first try to connect to the same peripheral instance for 2 sec (the original DFU bootloader uses direct advertising with very small advertising interval, so this should work), and will start scanning for a device matching peripheral selector on timeout.
- When starting sending second part of an update, the library will first try to reconnect to the same device (as it's already in bootloader mode). When this times out it will start scanning as it did before.