### PR TITLE
App not responding issue fixed

### DIFF
--- a/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
+++ b/Example/iOSDFULibrary/View Controllers/DFUViewController.swift
@@ -125,7 +125,9 @@ class DFUViewController: UIViewController, CBCentralManagerDelegate, DFUServiceD
             partLabel.text = "1 / \(firmware.parts)"
             
             startTime = Date()
-            timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(DFUViewController.updateTimer), userInfo: nil, repeats: true)
+            timer = Timer.scheduledTimer(timeInterval: 1.0, target: self,
+                                         selector: #selector(DFUViewController.updateTimer),
+                                         userInfo: nil, repeats: true)
             updateTimer()
         } else {
             dfuStatusLabel.text = "Loading firmware..."


### PR DESCRIPTION
This PR fixes the issue with the sample app, when after selecting the target the app was frozen for ~ 5 seconds loading firmwares. Now the load is offloaded to background thread and the app will display "Loading firmware..." instead. Small update, but useful.