### PR TITLE
Add links to Xamarin binding libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ A library for both iOS and Android that is based on this library is available fo
 
 ### Xamarin
 
-Simple binding libraries for iOS and Android are available on nuget:
-[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+Simple binding library for iOS is available on nuget:
 [xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ An unofficial library for both iOS and Android that is based on this library is 
 A library for both iOS and Android that is based on this library is available for Flutter: 
 [flutter-nordic-dfu](https://github.com/fengqiangboy/flutter-nordic-dfu) 
 
+### Xamarin
+
+Simple binding libraries for iOS and Android are available on nuget:
+[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+[xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
+
 ---
 
 ### Resources


### PR DESCRIPTION
We have been using these libraries for our Xamarin apps for some time, and are committed to maintaining them. Would be nice if you could put up the link to them on the github repo.