### PR TITLE
Support for apple watchOS and tvOS on pods

### DIFF
--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -15,7 +15,8 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'
-  s.watchos.deployment_target = '5.0'
+  s.tvos.deployment_target = '11.0'
+  s.watchos.deployment_target = '4.0'
 
   s.source_files = 'iOSDFULibrary/Classes/**/*'
 

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -15,6 +15,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'
+  s.watchos.deployment_target = '5.0'
 
   s.source_files = 'iOSDFULibrary/Classes/**/*'
 


### PR DESCRIPTION
IOS-Pods-DFU-Library compatible with apple watch.
Tested on version 5, 6, and 7 watchOS versions. So minimal tested version is 5.0.