### PR TITLE
Unwrapping optionals fixed

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -117,7 +117,9 @@ extension BaseDFUExecutor {
     
     func error(_ error: DFUError, didOccurWithMessage message: String) {
         if error == .bluetoothDisabled {
-            delegate{ $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message) }
+            delegate {
+                $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message)                
+            }
             // Release the cyclic reference.
             peripheral.destroy()
             return

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -101,8 +101,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     internal let experimentalButtonlessServiceInSecureDfuEnabled: Bool
     /// Default error callback.
     internal var defaultErrorCallback: ErrorCallback {
-        return { (error, message) in
-            self.delegate?.error(error, didOccurWithMessage: message)
+        return { [weak self] error, message in
+            self?.delegate?.error(error, didOccurWithMessage: message)
         }
     }
 
@@ -155,9 +155,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         }
         self.peripheral = peripheral
         
-        if peripheral.state != .connected {
-            connect()
-        } else {
+        switch peripheral.state {
+        case .connected:
             let name = peripheral.name ?? "Unknown device"
             logger.i("Connected to \(name)")
             
@@ -171,6 +170,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
                 // Let's discover DFU services.
                 discoverServices()
             }
+        default:
+            connect()
         }
     }
     
@@ -239,10 +240,11 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             stateAsString = "Unknown"
         }
         logger.d("[Callback] Central Manager did update state to: \(stateAsString)")
-        if central.state == .poweredOn {
+        switch central.state {
+        case .poweredOn:
             // We are now ready to rumble!
             start()
-        } else {
+        default:
             // The device has been already disconnected if it was connected.
             delegate?.error(.bluetoothDisabled, didOccurWithMessage: "Bluetooth adapter powered off")
             destroy()
@@ -339,11 +341,10 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     // MARK: - Peripheral Delegate methods
     
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        guard error == nil else {
+        if let error = error {
             logger.e("Services discovery failed")
-            logger.e(error!)
-            delegate?.error(.serviceDiscoveryFailed, didOccurWithMessage:
-                "Services discovery failed")
+            logger.e(error)
+            delegate?.error(.serviceDiscoveryFailed, didOccurWithMessage: "Services discovery failed")
             return
         }
         
@@ -370,8 +371,7 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             logger.d("Did you connect to the correct target? It might be that the previous services were cached: toggle Bluetooth from iOS settings to clear cache. Also, ensure the device contains the Service Changed characteristic")
             
             // The device does not support DFU, nor buttonless jump
-            delegate?.error(.deviceNotSupported, didOccurWithMessage:
-                "DFU Service not found")
+            delegate?.error(.deviceNotSupported, didOccurWithMessage: "DFU Service not found")
             return
         }
         // A DFU service was found, congratulations!
@@ -409,7 +409,7 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
      This method should reset the device, preferably switching it to application mode.
      */
     func resetDevice() {
-        if peripheral != nil && peripheral!.state != .disconnected {
+        if let peripheral = peripheral, peripheral.state != .disconnected {
             disconnect()
         } else {
             peripheralDidDisconnect()
@@ -424,27 +424,17 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
      - returns: A `DFUService` type if a DFU service has been found, or `nil` if
                 services are `nil` or the list does not contain any supported DFU Service.
      */
-    private func findDfuService(in services:[CBService]?) -> CBService? {
-        if let services = services {
-            for service in services {
-                // Skip the experimental Buttonless DFU Service if this feature wasn't enabled.
-                if experimentalButtonlessServiceInSecureDfuEnabled && service.matches(uuid: uuidHelper.buttonlessExperimentalService) {
-                    // The experimental Buttonless DFU Service for Secure DFU has been found.
-                    return service
-                }
-
-                if service.matches(uuid: uuidHelper.secureDFUService) {
-                    // Secure DFU Service has been found.
-                    return service
-                }
-
-                if service.matches(uuid: uuidHelper.legacyDFUService) {
-                    // Legacy DFU Service has been found.
-                    return service
-                }
-            }
+    private func findDfuService(in services: [CBService]?) -> CBService? {
+        return services?.first { service in
+            // The experimental Buttonless DFU Service for Secure DFU has been found.
+            // Skip the experimental Buttonless DFU Service if this feature wasn't enabled.
+            (experimentalButtonlessServiceInSecureDfuEnabled &&
+                service.matches(uuid: uuidHelper.buttonlessExperimentalService)) ||
+            // Secure DFU Service has been found.
+            service.matches(uuid: uuidHelper.secureDFUService) ||
+            // Legacy DFU Service has been found.
+            service.matches(uuid: uuidHelper.legacyDFUService)
         }
-        return nil
     }
     
     /**
@@ -651,7 +641,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
             // This part of firmware has been successfully sent.
             
             // Check if there is another part to be sent.
-            if (delegate?.peripheralDidDisconnectAfterFirmwarePartSent() ?? false) {
+            if delegate?.peripheralDidDisconnectAfterFirmwarePartSent() == true {
                 // As we are already in bootloader mode, the peripheral set
                 // may be reused for sending a second part.
                 connectOrSwitchToNewPeripheral(after: 15.0)
@@ -695,9 +685,9 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
         // With that flag equal to true, the library will try to connect to the
         // same device (with a short timeout), and if that fails, will try to
         // scan for a new address using `DFUPeripheralSelector`.
-        connect(withTimeout: timeout) { [unowned self] in
+        connect(withTimeout: timeout) { [weak self] in
             // Scan for a new device and connect to it.
-            self.switchToNewPeripheralAndConnect()
+            self?.switchToNewPeripheralAndConnect()
         }
     }
     

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -161,16 +161,15 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             let name = peripheral.name ?? "Unknown device"
             logger.i("Connected to \(name)")
             
-            let dfuService = findDfuService(in: peripheral.services)
-            if dfuService == nil {
+            if let dfuService = findDfuService(in: peripheral.services) {
+                // A DFU service was found, congratulations!
+                logger.i("Services discovered")
+                peripheralDidDiscoverDfuService(dfuService)
+            } else {
                 // DFU service has not been found, but it doesn't matter it's not
                 // there. Perhaps the user's application didn't discover it.
                 // Let's discover DFU services.
                 discoverServices()
-            } else {
-                // A DFU service was found, congratulations!
-                logger.i("Services discovered")
-                peripheralDidDiscoverDfuService(dfuService!)
             }
         }
     }
@@ -181,13 +180,14 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     }
     
     func disconnect() {
-        if peripheral!.state == .connected {
+        guard let peripheral = peripheral else { return }
+        if peripheral.state == .connected {
             logger.v("Disconnecting...")
         } else {
             logger.v("Cancelling connection...")
         }
         logger.d("centralManager.cancelPeripheralConnection(peripheral)")
-        centralManager.cancelPeripheralConnection(peripheral!)
+        centralManager.cancelPeripheralConnection(peripheral)
     }
     
     func destroy() {
@@ -703,7 +703,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
     
     func switchToNewPeripheralAndConnect() {
         // Release the previous peripheral.
-        peripheral!.delegate = nil
+        peripheral?.delegate = nil
         peripheral = nil
         cleanUp()
         

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
@@ -69,10 +69,10 @@ internal class DFUPacket: DFUCharacteristic {
         // Get the peripheral object
         let peripheral = characteristic.service.peripheral
         
-        var data = Data(capacity: 12)
-        data += size.softdevice.littleEndian
-        data += size.bootloader.littleEndian
-        data += size.application.littleEndian
+        let data = Data()
+            + size.softdevice.littleEndian
+            + size.bootloader.littleEndian
+            + size.application.littleEndian
 
         let packetUUID = characteristic.uuid.uuidString
         
@@ -91,9 +91,8 @@ internal class DFUPacket: DFUCharacteristic {
         // Get the peripheral object.
         let peripheral = characteristic.service.peripheral
         
-        var data = Data(capacity: 4)
-        data += size.application.littleEndian
-
+        let data = Data() + size.application.littleEndian
+        
         let packetUUID = characteristic.uuid.uuidString
 
         logger.v("Writing image size (\(size.application)b) to characteristic \(packetUUID)...")
@@ -167,14 +166,15 @@ internal class DFUPacket: DFUCharacteristic {
             lastTime = startTime
             
             // Notify progress delegate that upload has started (0%).
-            queue.async(execute: {
+            queue.async {
                 progress?.dfuProgressDidChange(
                     for:   firmware.currentPart,
                     outOf: firmware.parts,
                     to:    0,
                     currentSpeedBytesPerSecond: 0.0,
-                    avgSpeedBytesPerSecond:     0.0)
-            })
+                    avgSpeedBytesPerSecond:     0.0
+                )
+            }
         }
         
         while packetsToSendNow > 0 {
@@ -212,14 +212,15 @@ internal class DFUPacket: DFUCharacteristic {
                 lastTime = now
                 bytesSentSinceProgessNotification = bytesSent
                 
-                queue.async(execute: {
+                queue.async {
                     progress?.dfuProgressDidChange(
                         for:   firmware.currentPart,
                         outOf: firmware.parts,
                         to:    Int(currentProgress),
                         currentSpeedBytesPerSecond: currentSpeed,
-                        avgSpeedBytesPerSecond:     avgSpeed)
-                })
+                        avgSpeedBytesPerSecond:     avgSpeed
+                    )
+                }
                 progressReported = currentProgress
             }
         }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -97,7 +97,7 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
         logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
         
         // Validate data length
-        if data == nil || data!.count != 2 {
+        if data?.count != 2 {
             logger.w("Invalid value: 2 bytes expected")
             report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
             return

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -86,27 +86,28 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
             return
         }
 
-        if error != nil {
+        if let error = error {
             logger.e("Reading DFU Version characteristic failed")
-            logger.e(error!)
+            logger.e(error)
             report?(.readingVersionFailed, "Reading DFU Version characteristic failed")
-        } else {
-            let data = characteristic.value
-            logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
-            
-            // Validate data length
-            if data == nil || data!.count != 2 {
-                logger.w("Invalid value: 2 bytes expected")
-                report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
-                return
-            }
-            
-            // Read major and minor
-            let minor: UInt8 = data![0]
-            let major: UInt8 = data![1]
-            
-            logger.a("Version number read: \(major).\(minor)")
-            success?(major, minor)
+            return
         }
+        
+        let data = characteristic.value
+        logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
+        
+        // Validate data length
+        if data == nil || data!.count != 2 {
+            logger.w("Invalid value: 2 bytes expected")
+            report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
+            return
+        }
+        
+        // Read major and minor
+        let minor: UInt8 = data![0]
+        let major: UInt8 = data![1]
+        
+        logger.a("Version number read: \(major).\(minor)")
+        success?(major, minor)
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -88,7 +88,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { (error, message) in
+            onError: { error, message in
                 self.jumpingToBootloader = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }
@@ -219,7 +219,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.sendActivateAndResetRequest(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { (error, message) in
+            onError: { error, message in
                 self.activating = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -44,7 +44,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // characteristic was introduced (SDK 7.0.0). It version exists, and we are not
         // in Application mode, then the Init Packet is required.
         
-        if let version = dfuService!.version {
+        if let version = dfuService?.version {
             // In the application mode we don't know whether init packet is required
             // as the app is indepenrent from the DFU Bootloader.
             let isInApplicationMode = version.major == 0 && version.minor == 1
@@ -59,14 +59,14 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      Enables notifications on DFU Control Point characteristic.
      */
     func enableControlPoint() {
-        dfuService!.enableControlPoint(
+        dfuService?.enableControlPoint(
             onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
     
     override func isInApplicationMode(_ forceDfu: Bool) -> Bool {
-        let applicationMode = dfuService!.isInApplicationMode() ?? !forceDfu
+        let applicationMode = dfuService?.isInApplicationMode() ?? !forceDfu
         
         if applicationMode {
             logger.w("Application with buttonless update found")
@@ -82,9 +82,10 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
                                   with a different address than when in app mode.
      */
     func jumpToBootloader(forceNewAddress: Bool) {
+        guard let dfuService = dfuService else { return }
         jumpingToBootloader = true
-        newAddressExpected = dfuService!.newAddressExpected || forceNewAddress
-        dfuService!.jumpToBootloaderMode(
+        newAddressExpected = dfuService.newAddressExpected || forceNewAddress
+        dfuService.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             onError: { (error, message) in
@@ -108,7 +109,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      - parameter size: The size of all parts of the firmware.
      */
     func sendStartDfu(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize) {
-        dfuService!.sendDfuStart(withFirmwareType: type, andSize: size,
+        dfuService?.sendDfuStart(withFirmwareType: type, andSize: size,
             onSuccess: { self.delegate?.peripheralDidStartDfu() },
             onError: { error, message in
                 if error == .remoteLegacyDFUNotSupported {
@@ -131,6 +132,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
                        Softdevice and Bootloader are 0.
      */
     func sendStartDfu(withFirmwareSize size: DFUFirmwareSize) {
+        guard let dfuService = dfuService else { return }
         logger.v("Switching to DFU v.1")
         
         // Flash operation in DFU Bootloaders from SDK 6.0 and older were too slow
@@ -138,7 +140,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // Also, a 1000ms delay is required before starting sending data.
         slowDfuMode = true
         
-        dfuService!.sendStartDfu(withFirmwareSize: size,
+        dfuService.sendStartDfu(withFirmwareSize: size,
             onSuccess: { self.delegate?.peripheralDidStartDfu() },
             onError: defaultErrorCallback
         )
@@ -151,7 +153,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      - parameter data: Init Packet data.
      */
     func sendInitPacket(_ data: Data) {
-        dfuService!.sendInitPacket(data,
+        dfuService?.sendInitPacket(data,
             onSuccess: { self.delegate?.peripheralDidReceiveInitPacket() },
             onError: defaultErrorCallback
         )
@@ -178,10 +180,10 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
             // Otherwise, the device could send error 6: Operation failed.
             prn = 1
         }
-        dfuService!.sendPacketReceiptNotificationRequest(prn,
+        dfuService?.sendPacketReceiptNotificationRequest(prn,
             onSuccess: {
                 // Now the service is ready to send the firmware.
-                self.dfuService!.sendFirmware(firmware, withDelay: self.slowDfuMode,
+                self.dfuService?.sendFirmware(firmware, withDelay: self.slowDfuMode,
                     andReportProgressTo: progress, on: queue,
                     onSuccess: { self.delegate?.peripheralDidReceiveFirmware() },
                     onError: self.defaultErrorCallback
@@ -196,7 +198,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      On success, the `delegate.peripheralDidVerifyFirmware()` method will be called.
      */
     func validateFirmware() {
-        dfuService!.sendValidateFirmwareRequest(
+        dfuService?.sendValidateFirmwareRequest(
             onSuccess: { self.delegate?.peripheralDidVerifyFirmware() },
             onError: defaultErrorCallback
         )
@@ -206,6 +208,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      Sends the Activate and Reset command to the DFU Control Point characteristic.
      */
     func activateAndReset() {
+        guard let dfuService = dfuService else { return }
         activating = true
         
         // In Legacy DFU the Buttonless service does not increment the device address.
@@ -213,7 +216,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // and may use incremented MAC address to receive the second part.
         newAddressExpected = true
         
-        dfuService!.sendActivateAndResetRequest(
+        dfuService.sendActivateAndResetRequest(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             onError: { (error, message) in

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -105,16 +105,19 @@ import CoreBluetooth
     }
     
     func resume() -> Bool {
-        if !aborted && paused && firmware != nil {
+        guard let dfuPacketCharacteristic = dfuPacketCharacteristic,
+              let firmware = firmware,
+              let progressQueue = progressQueue,
+              !aborted && paused else {
             paused = false
-            // onSuccess and onError callbacks are still kept by dfuControlPointCharacteristic.
-            dfuPacketCharacteristic!.sendNext(packetReceiptNotificationNumber,
-                                              packetsOf: firmware!,
-                                              andReportProgressTo: progressDelegate,
-                                              on: progressQueue!)
             return paused
         }
         paused = false
+        // onSuccess and onError callbacks are still kept by dfuControlPointCharacteristic.
+        dfuPacketCharacteristic.sendNext(packetReceiptNotificationNumber,
+                                          packetsOf: firmware,
+                                          andReportProgressTo: progressDelegate,
+                                          on: progressQueue)
         return paused
     }
     
@@ -123,8 +126,7 @@ import CoreBluetooth
         // When upload has been started and paused, we have to send the Reset command
         // here as the device will not get a Packet Receipt Notification. If it hasn't
         // been paused, the Reset command will be sent after receiving it, on line 380.
-        if paused && firmware != nil {
-            let _report = report!
+        if let _report = report, paused && firmware != nil {
             firmware = nil
             success  = nil
             report   = nil
@@ -192,8 +194,8 @@ import CoreBluetooth
         // - we must be in the DFU mode already (otherwise the device would be useless...).
         // Note: On iOS the Generic Access and Generic Attribute services (nor HID Service)
         //       are not returned during service discovery.
-        let services = service.peripheral.services!
-        if services.count == 1 {
+        let services = service.peripheral.services
+        if services?.count == 1 {
             return false
         }
         // If there are more services than just DFU Service, the state is uncertain.
@@ -226,7 +228,7 @@ import CoreBluetooth
     func enableControlPoint(onSuccess success: @escaping Callback,
                             onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.enableNotifications(onSuccess: success, onError: report)
+            dfuControlPointCharacteristic?.enableNotifications(onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
         }
@@ -239,7 +241,7 @@ import CoreBluetooth
      */
     func jumpToBootloaderMode(onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.jumpToBootloader,
+            dfuControlPointCharacteristic?.send(Request.jumpToBootloader,
                                                 onSuccess: nil, onError: report)
         } else {
             sendReset(onError: report)
@@ -248,8 +250,8 @@ import CoreBluetooth
     
     /**
      This methods sends the Start DFU command with the firmware type to the DFU Control
-     Point characterristic, followed by the sizes of each firware component
-     <softdevice, bootloader, application> (each as UInt32, Little Endian).
+     Point characterristic, followed by the sizes of each firware component:
+     softdevice, bootloader, application (each as UInt32, Little Endian).
      
      - parameter type:    The type of the current firmware part.
      - parameter size:    The sizes of firmware components in the current part.
@@ -257,7 +259,8 @@ import CoreBluetooth
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendDfuStart(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize,
-                      onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                      onSuccess success: @escaping Callback,
+                      onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -276,20 +279,25 @@ import CoreBluetooth
         //    it would receive a response with status = 6 (Operation failed) after sending
         //    some firmware packets. Delay 1 sec seems to work while 600 ms was too short.
         //    The time seems to be required to prepare flash(?).
-        let sendStartDfu = {
+        let sendStartDfu = { [weak self] in
+            guard let self = self else { return }
             // 1. Sends the Start DFU command with the firmware type to DFU Control Point
             //    characteristic.
             // 2. Sends firmware sizes to DFU Packet characteristic.
             // 3. Receives response notification and calls onSuccess or onError.
-            self.dfuControlPointCharacteristic!.send(Request.startDfu(type: type), onSuccess: success) { (error, aMessage) in
-                if error == .remoteLegacyDFUInvalidState {
-                    self.targetPeripheral!.shouldReconnect = true
-                    self.sendReset(onError: report)
-                    return
+            self.dfuControlPointCharacteristic?.send(Request.startDfu(type: type),
+                onSuccess: success,
+                onError: { [weak self] error, message in
+                    guard let self = self else { return }
+                    if error == .remoteLegacyDFUInvalidState {
+                        self.targetPeripheral?.shouldReconnect = true
+                        self.sendReset(onError: report)
+                        return
+                    }
+                    report(error, message)
                 }
-                report(error, aMessage)
-            }
-            self.dfuPacketCharacteristic!.sendFirmwareSize(size)
+            )
+            self.dfuPacketCharacteristic?.sendFirmwareSize(size)
         }
         if version != nil {
             // The legacy DFU bootloader from SDK 7.0+ does not require delay.
@@ -304,15 +312,15 @@ import CoreBluetooth
     
     /**
      This methods sends the old Start DFU command (without the firmware type) to the
-     DFU Control Point characterristic, followed by the application size
-     <application> (UInt32, Little Endian).
+     DFU Control Point characterristic, followed by the application size (UInt32, Little Endian).
      
      - parameter size:    The sizes of firmware components in the current part.
      - parameter success: A callback called when a response with status Success is received.
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendStartDfu(withFirmwareSize size: DFUFirmwareSize,
-                      onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                      onSuccess success: @escaping Callback,
+                      onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -320,21 +328,24 @@ import CoreBluetooth
         
         // See comment in sendDfuStart(withFirmwareType:andSize:onSuccess:onError) above
         logger.d("wait(1000)")
-        queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+        queue.asyncAfter(deadline: .now() + .milliseconds(1000)) { [weak self] in
+            guard let self = self else { return }
             // 1. Sends the Start DFU command with the firmware type to the DFU Control Point
             //    characteristic.
             // 2. Sends firmware sizes to the DFU Packet characteristic.
             // 3. Receives response notification and calls onSuccess or onError.
-            self.dfuControlPointCharacteristic!.send(Request.startDfu_v1, onSuccess: success) {
-                (error, aMessage) in
-                if error == .remoteLegacyDFUInvalidState {
-                    self.targetPeripheral!.shouldReconnect = true
-                    self.sendReset(onError: report)
-                    return
-                }
-                report(error, aMessage)
-            }
-            self.dfuPacketCharacteristic!.sendFirmwareSize_v1(size)
+            self.dfuControlPointCharacteristic?.send(Request.startDfu_v1,
+                onSuccess: success,
+                onError: { [weak self] error, message in
+                    guard let self = self else { return }
+                    if error == .remoteLegacyDFUInvalidState {
+                        self.targetPeripheral!.shouldReconnect = true
+                        self.sendReset(onError: report)
+                        return
+                    }
+                    report(error, message)
+                })
+            self.dfuPacketCharacteristic?.sendFirmwareSize_v1(size)
         }
     }
     
@@ -352,7 +363,8 @@ import CoreBluetooth
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendInitPacket(_ data: Data,
-                        onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                        onSuccess success: @escaping Callback,
+                        onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -378,11 +390,16 @@ import CoreBluetooth
             // Therefore, there are 2 commands to the DFU Control Point required: one
             // before we start sending init packet, and another one the whole init packet
             // is sent. After sending the second packet a notification will be received.
-            dfuControlPointCharacteristic!.send(Request.initDfuParameters(req: InitDfuParametersRequest.receiveInitPacket), onSuccess: nil, onError: report)
-            dfuPacketCharacteristic!.sendInitPacket(data)
-            dfuControlPointCharacteristic!.send(Request.initDfuParameters(req: InitDfuParametersRequest.initPacketComplete), onSuccess: success,
-                onError: {
-                    error, message in
+            dfuControlPointCharacteristic?.send(
+                Request.initDfuParameters(req: InitDfuParametersRequest.receiveInitPacket),
+                onSuccess: nil,
+                onError: report
+            )
+            dfuPacketCharacteristic?.sendInitPacket(data)
+            dfuControlPointCharacteristic?.send(
+                Request.initDfuParameters(req: InitDfuParametersRequest.initPacketComplete),
+                onSuccess: success,
+                onError: { error, message in
                     if error == .remoteLegacyDFUOperationFailed {
                         // Init packet validation failed. The device type, revision, app
                         // version or SoftDevice version does not match values specified
@@ -400,9 +417,9 @@ import CoreBluetooth
             // After receiving this packet the DFU target was sending a notification with
             // status.
             if data.count == 2 {
-                dfuControlPointCharacteristic!.send(Request.initDfuParameters_v1,
+                dfuControlPointCharacteristic?.send(Request.initDfuParameters_v1,
                                                     onSuccess: success, onError: report)
-                dfuPacketCharacteristic!.sendInitPacket(data)
+                dfuPacketCharacteristic?.sendInitPacket(data)
             } else {
                 // After sending the Extended Init Packet, the DFU would fail on CRC
                 // validation eventually.
@@ -436,7 +453,7 @@ import CoreBluetooth
                                               onError report: @escaping ErrorCallback) {
         if !aborted {
             packetReceiptNotificationNumber = prnValue
-            dfuControlPointCharacteristic!.send(Request.packetReceiptNotificationRequest(number: prnValue),
+            dfuControlPointCharacteristic?.send(Request.packetReceiptNotificationRequest(number: prnValue),
                                                 onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
@@ -472,11 +489,13 @@ import CoreBluetooth
         // 2. Sends firmware to the DFU Packet characteristic. If number > 0 it will receive
         //    Packet Receit Notifications every number packets.
         // 3. Receives response notification and calls onSuccess or onError.
-        dfuControlPointCharacteristic!.send(Request.receiveFirmwareImage,
-            onSuccess: {
+        dfuControlPointCharacteristic?.send(Request.receiveFirmwareImage,
+            onSuccess: { [weak self] in
+                guard let self = self else { return }
                 // Register callbacks for Packet Receipt Notifications/Responses.
-                self.dfuControlPointCharacteristic!.waitUntilUploadComplete(
-                    onSuccess: {
+                self.dfuControlPointCharacteristic?.waitUntilUploadComplete(
+                    onSuccess: { [weak self] in
+                        guard let self = self else { return }
                         // Upload is completed, release the temporary parameters.
                         self.firmware = nil
                         self.report   = nil
@@ -484,8 +503,8 @@ import CoreBluetooth
                         self.progressQueue = nil
                         success()
                     },
-                    onPacketReceiptNofitication: {
-                        bytesReceived in
+                    onPacketReceiptNofitication: { [weak self] bytesReceived in
+                        guard let self = self else { return }
                         // This callback is called from SecureDFUControlPoint in 2 cases:
                         // when a PRN is received (bytesReceived contains number of bytes
                         // reported), or when the iOS reports the
@@ -499,14 +518,21 @@ import CoreBluetooth
                         
                         // Each time a PRN is received, send next bunch of packets
                         if !self.paused && !self.aborted {
-                            let bytesSent = self.dfuPacketCharacteristic!.bytesSent
+                            guard let dfuPacketCharacteristic = self.dfuPacketCharacteristic else {
+                                self.firmware = nil
+                                self.report   = nil
+                                self.progressDelegate = nil
+                                self.progressQueue = nil
+                                return
+                            }
+                            let bytesSent = dfuPacketCharacteristic.bytesSent
                             // Due to https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/54
                             // only 16 least significant bits are verified.
                             if peripheralIsReadyToSendWriteWithoutRequest ||
                                (bytesSent & 0xFFFF) == (bytesReceived! & 0xFFFF) {
-                                self.dfuPacketCharacteristic!.sendNext(self.packetReceiptNotificationNumber,
-                                                                       packetsOf: firmware,
-                                                                       andReportProgressTo: progress, on: queue)
+                                dfuPacketCharacteristic.sendNext(self.packetReceiptNotificationNumber,
+                                                                 packetsOf: firmware,
+                                                                 andReportProgressTo: progress, on: queue)
                             } else {
                                 // Target device deported invalid number of bytes received
                                 report(.bytesLost, "\(bytesSent) bytes were sent while \(bytesReceived!) bytes were reported as received")
@@ -521,8 +547,8 @@ import CoreBluetooth
                             self.sendReset(onError: report)
                         }
                     },
-                    onError: {
-                        error, message in
+                    onError: { [weak self] error, message in
+                        guard let self = self else { return }
                         // Upload failed, release the temporary parameters.
                         self.firmware = nil
                         self.report   = nil
@@ -533,10 +559,11 @@ import CoreBluetooth
                 )
                 // ...and start sending firmware.
                 if !self.paused && !self.aborted {
-                    let start = {
+                    let start = { [weak self] in
+                        guard let self = self else { return }
                         self.logger.a("Uploading firmware...")
                         self.logger.v("Sending firmware to DFU Packet characteristic...")
-                        self.dfuPacketCharacteristic!.sendNext(self.packetReceiptNotificationNumber,
+                        self.dfuPacketCharacteristic?.sendNext(self.packetReceiptNotificationNumber,
                                                                packetsOf: firmware,
                                                                andReportProgressTo: progress, on: queue)
                     }
@@ -558,7 +585,8 @@ import CoreBluetooth
                     self.sendReset(onError: report)
                 }
             },
-            onError: report)
+            onError: report
+        )
     }
     
     /**
@@ -570,7 +598,7 @@ import CoreBluetooth
     func sendValidateFirmwareRequest(onSuccess success: @escaping Callback,
                                      onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.validateFirmware,
+            dfuControlPointCharacteristic?.send(Request.validateFirmware,
                                                 onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
@@ -585,7 +613,7 @@ import CoreBluetooth
      */
     func sendActivateAndResetRequest(onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.activateAndReset,
+            dfuControlPointCharacteristic?.send(Request.activateAndReset,
                                                 onSuccess: nil, onError: report)
         } else {
             sendReset(onError: report)
@@ -600,7 +628,7 @@ import CoreBluetooth
      - parameter report: A callback called when writing characteristic failed.
      */
     func sendReset(onError report: @escaping ErrorCallback) {
-        dfuControlPointCharacteristic!.send(Request.reset, onSuccess: nil, onError: report)
+        dfuControlPointCharacteristic?.send(Request.reset, onSuccess: nil, onError: report)
     }
     
     // MARK: - Private service API methods
@@ -614,13 +642,13 @@ import CoreBluetooth
     */
     private func readDfuVersion(onSuccess success: @escaping Callback,
                                 onError report: @escaping ErrorCallback) {
-        dfuVersionCharacteristic!.readVersion(
-            onSuccess: {
-                major, minor in
+        dfuVersionCharacteristic?.readVersion(
+            onSuccess: { [weak self] major, minor in
+                guard let self = self else { return }
                 self.version = (major, minor)
                 success()
             },
-            onError:report
+            onError: report
         )
     }
     
@@ -693,7 +721,12 @@ import CoreBluetooth
                 _report?(.readingVersionFailed, "DFU Version found, but does not have the Read property")
                 return
             }
-            readDfuVersion(onSuccess: _success!, onError: _report!)
+            guard let _success = _success,
+                  let _report = _report else {
+                // This should never happen.
+                return
+            }
+            readDfuVersion(onSuccess: _success, onError: _report)
         } else {
             // Else... proceed.
             version = nil

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -100,18 +100,17 @@ internal struct ButtonlessDFUResponse {
     init?(_ data: Data) {
         // The correct response is always 3 bytes long: Response Op Code,
         // Request Op Code and Status.
-        guard data.count == 3 else { return nil }
-        let opCode        = ButtonlessDFUOpCode(rawValue: data[0])
-        let requestOpCode = ButtonlessDFUOpCode(rawValue: data[1])
-        let status        = ButtonlessDFUResultCode(rawValue: data[2])
-        
-        if opCode != .responseCode || requestOpCode == nil || status == nil {
+        guard data.count == 3,
+              let opCode = ButtonlessDFUOpCode(rawValue: data[0]),
+              let requestOpCode = ButtonlessDFUOpCode(rawValue: data[1]),
+              let status = ButtonlessDFUResultCode(rawValue: data[2]),
+              opCode == .responseCode else {
             return nil
         }
         
-        self.opCode        = opCode!
-        self.requestOpCode = requestOpCode!
-        self.status        = status!
+        self.opCode        = opCode
+        self.requestOpCode = requestOpCode
+        self.status        = status
     }
         
     var description: String {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -143,14 +143,15 @@ internal class SecureDFUPacket: DFUCharacteristic {
             totalBytesSentSinceProgessNotification = totalBytesSentWhenDfuStarted
             
             // Notify progress delegate that upload has started (0%).
-            queue.async(execute: {
+            queue.async {
                 progress?.dfuProgressDidChange(
                     for:   firmware.currentPart,
                     outOf: firmware.parts,
                     to:    0,
                     currentSpeedBytesPerSecond: 0.0,
-                    avgSpeedBytesPerSecond:     0.0)
-            })
+                    avgSpeedBytesPerSecond:     0.0
+                )
+            }
         }
         
         let originalPacketsToSendNow = packetsToSendNow
@@ -189,14 +190,15 @@ internal class SecureDFUPacket: DFUCharacteristic {
                 totalBytesSentSinceProgessNotification = totalBytesSent
                 
                 // Notify progress delegate of overall progress.
-                queue.async(execute: {
+                queue.async {
                     progress?.dfuProgressDidChange(
                         for:   firmware.currentPart,
                         outOf: firmware.parts,
                         to:    Int(currentProgress),
                         currentSpeedBytesPerSecond: currentSpeed,
-                        avgSpeedBytesPerSecond:     avgSpeed)
-                })
+                        avgSpeedBytesPerSecond:     avgSpeed
+                    )
+                }
                 progressReported = currentProgress
             }
             

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUServiceInitiator.swift
@@ -36,8 +36,7 @@ import CoreBluetooth
         // The firmware file must be specified before calling `start(...)`.
         guard let _ = file else {
             delegateQueue.async {
-                self.delegate?.dfuError(.fileNotSpecified, didOccurWithMessage:
-                    "Firmware not specified")
+                self.delegate?.dfuError(.fileNotSpecified, didOccurWithMessage: "Firmware not specified")
             }
             return nil
         }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -73,14 +73,14 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      Enables notifications on DFU Control Point characteristic.
      */
     func enableControlPoint() {
-        dfuService!.enableControlPoint(
+        dfuService?.enableControlPoint(
             onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
     
     override func isInApplicationMode(_ forceDfu: Bool) -> Bool {
-        let applicationMode = dfuService!.isInApplicationMode() ?? !forceDfu
+        let applicationMode = dfuService?.isInApplicationMode() ?? !forceDfu
         
         if applicationMode {
             logger.w("Application with buttonless update found")
@@ -97,15 +97,16 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      in `DFUServiceInitiator`.
      */
     func jumpToBootloader() {
-        newAddressExpected = dfuService!.newAddressExpected
+        guard let dfuService = dfuService else { return }
+        newAddressExpected = dfuService.newAddressExpected
 
         var name: String?
         if alternativeAdvertisingNameEnabled {
             if let userSuppliedName = alternativeAdvertisingName {
-                // Use the user supplied name
+                // Use the user supplied name.
                 name = userSuppliedName
             } else {
-                // Generate a random 8-character long name
+                // Generate a random 8-character long name.
                 name = String(format: "Dfu%05d", arc4random_uniform(100000))
             }
         }
@@ -113,7 +114,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         // See `peripheralDidDisconnect()` for details.
         possibleDisconnectionOnSettingAlternativeName = name != nil
         
-        dfuService!.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
+        dfuService.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
             onSuccess: {
                 self.jumpingToBootloader = true
                 // The device will now disconnect and
@@ -150,11 +151,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      object size.
      */
     func readDataObjectInfo() {
-        dfuService!.readDataObjectInfo(
-            onReponse: { (response) in
-                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response!.maxSize!,
-                                                               offset: response!.offset!,
-                                                               crc: response!.crc!)
+        dfuService?.readDataObjectInfo(
+            onReponse: { response in
+                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response.maxSize!,
+                                                               offset: response.offset!,
+                                                               crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -165,11 +166,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      object size.
      */
     func readCommandObjectInfo() {
-        dfuService!.readCommandObjectInfo(
-            onReponse: { (response) in
-                self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response!.maxSize!,
-                                                                  offset: response!.offset!,
-                                                                  crc: response!.crc!)
+        dfuService?.readCommandObjectInfo(
+            onReponse: { response in
+                self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response.maxSize!,
+                                                                  offset: response.offset!,
+                                                                  crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -181,7 +182,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter length: Exact size of the object.
      */
     func createDataObject(withLength length: UInt32) {
-        dfuService!.createDataObject(withLength: length,
+        dfuService?.createDataObject(withLength: length,
              onSuccess: { self.delegate?.peripheralDidCreateDataObject() },
              onError: defaultErrorCallback
         )
@@ -193,7 +194,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter length: Exact size of the object.
      */
     func createCommandObject(withLength length: UInt32) {
-        dfuService!.createCommandObject(withLength: length,
+        dfuService?.createCommandObject(withLength: length,
             onSuccess: { self.delegate?.peripheralDidCreateCommandObject() },
             onError: defaultErrorCallback
         )
@@ -210,7 +211,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func sendNextObject(from range: Range<Int>, of firmware: DFUFirmware,
                         andReportProgressTo progress: DFUProgressDelegate?,
                         on queue: DispatchQueue) {
-        dfuService!.sendNextObject(from: range, of: firmware,
+        dfuService?.sendNextObject(from: range, of: firmware,
             andReportProgressTo: progress, on: queue,
             onSuccess: { self.delegate?.peripheralDidReceiveObject() },
             onError: defaultErrorCallback
@@ -228,7 +229,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter newValue: Packet Receipt Notification value (0 to disable PRNs).
      */
     func setPRNValue(_ newValue: UInt16 = 0) {
-        dfuService!.setPacketReceiptNotificationValue(newValue,
+        dfuService?.setPacketReceiptNotificationValue(newValue,
             onSuccess: { self.delegate?.peripheralDidSetPRNValue() },
             onError: defaultErrorCallback
         )
@@ -245,7 +246,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         // It sends all bytes of init packet in up-to-20-byte packets.
         // The init packet may not be too long as sending > ~15 packets without
         // PRNs may lead to buffer overflow.
-        dfuService!.sendInitPacket(withdata: packetData)
+        dfuService?.sendInitPacket(withdata: packetData)
         self.delegate?.peripheralDidReceiveInitPacket()
     }
     
@@ -253,10 +254,10 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      Sends Calculate Checksum request.
      */
     func sendCalculateChecksumCommand() {
-        dfuService!.calculateChecksumCommand(
-            onSuccess: { (response) in
-                self.delegate?.peripheralDidSendChecksum(offset: response!.offset!,
-                                                         crc: response!.crc!)
+        dfuService?.calculateChecksumCommand(
+            onSuccess: { response in
+                self.delegate?.peripheralDidSendChecksum(offset: response.offset!,
+                                                         crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -276,7 +277,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func sendExecuteCommand(forCommandObject isCommandObject: Bool = false,
                             andActivateIf complete: Bool = false) {
         activating = complete
-        dfuService!.executeCommand(
+        dfuService?.executeCommand(
             onSuccess: { self.delegate?.peripheralDidExecuteObject() },
             onError: { (error, message) in
                 self.activating = false

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -120,7 +120,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                 // The device will now disconnect and
                 // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             },
-            onError: { (error, message) in
+            onError: { error, message in
                 self.jumpingToBootloader = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }
@@ -279,7 +279,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         activating = complete
         dfuService?.executeCommand(
             onSuccess: { self.delegate?.peripheralDidExecuteObject() },
-            onError: { (error, message) in
+            onError: { error, message in
                 self.activating = false
                 
                 // In SDK 15.2 (and perhaps 15.x), the DFU target may reoprt only full pages


### PR DESCRIPTION
In multiple places in the library optional variables that should never be *nil* were force-unwrapped. However, never say newer. It has been reported multiple times, e.g. in #394 , #213, #381. This PR fixes all force-unwrapped variables and makes sure they do not happen again. However, the behavior after the fixes is unknown. My assumption is, that the crashes were causes by sudden disconnection, which caused the DFU service being destroyed in the middle of uploading, so there should be no memory leaks, as everything gets cleaned up. But it may also happen, that the DFU process is in some weird state, that I cannot think of right now, that the service is disposed, but DFU executor is not, which would end up in handing cycling reference causing some objects not being disposed properly. But the chances of this are super low.