### PR TITLE
Fix protocol class inheritance deprecation warnings

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
@@ -66,7 +66,7 @@ import CoreBluetooth
  
  More: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
  */
-@objc public protocol DFUPeripheralSelectorDelegate : class {
+@objc public protocol DFUPeripheralSelectorDelegate : AnyObject {
     
     /**
      Returns whether the given peripheral is a device in DFU Bootloader mode.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -32,7 +32,7 @@ import CoreBluetooth
 
 typealias DelegateCallback = (DFUServiceDelegate) -> Void
 
-internal protocol BaseExecutorAPI : class, DFUController {
+internal protocol BaseExecutorAPI : AnyObject, DFUController {
     
     /**
      Starts the DFU operation.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-internal protocol BaseDFUPeripheralAPI : class, DFUController {
+internal protocol BaseDFUPeripheralAPI : AnyObject, DFUController {
     
     /**
      This method starts DFU process for given peripheral. If the peripheral is

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
@@ -28,7 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-internal protocol BasePeripheralDelegate : class {
+internal protocol BasePeripheralDelegate : AnyObject {
     
     /**
      Method called when the iDevice failed to connect to the given peripheral.

--- a/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
+++ b/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
@@ -65,7 +65,7 @@ import Foundation
 /**
  *  The Logger delegate.
  */
-@objc public protocol LoggerDelegate : class {
+@objc public protocol LoggerDelegate : AnyObject {
     
     /**
      This method is called whenever a new log entry is to be saved. The logger


### PR DESCRIPTION
This fixes the `Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead` warnings in Xcode.