### PR TITLE
Truncating too long advertising names

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -250,6 +250,9 @@ import CoreBluetooth
     /**
      If `alternativeAdvertisingNameEnabled` is `true` then this specifies the
      alternative name to use. If nil (default) then a random name is generated.
+     
+     The maximum length of the alertnative advertising name is 20 bytes.
+     Longer name will be trundated. UTF-8 characters can be cut in the middle.
      */
     @objc public var alternativeAdvertisingName: String? = nil
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -65,7 +65,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     
     override init(_ initiator: DFUServiceInitiator, _ logger: LoggerHelper) {
         self.alternativeAdvertisingNameEnabled = initiator.alternativeAdvertisingNameEnabled
-        self.alternativeAdvertisingName = initiator.alternativeAdvertisingName
+        self.alternativeAdvertisingName = initiator.alternativeAdvertisingName.map { String($0.prefix(20)) }
         super.init(initiator, logger)
     }
     


### PR DESCRIPTION
This PR fixes #395. The maximum length of alternative advertising name is 20 bytes. Longer names will be truncated. Encoding is not taken under consideration, so UTF-8 characters can be cut in the middle. To avoid such problems, make sure you either use random name (leave `alternativeAdvertisingName` as `nil`) or use less than 20 bytes.