### PR TITLE
Version 4.10

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 
 /* Begin PBXFileReference section */
 		012779F64413B4B66D6B2AD3E4413407 /* iOSDFULibrary-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSDFULibrary-iOS-prefix.pch"; sourceTree = "<group>"; };
-		030814F4129F5F1A94699B3DBF13B002 /* Pods_macOSDFULibrary_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_macOSDFULibrary_Example.framework; path = "Pods-macOSDFULibrary_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		030814F4129F5F1A94699B3DBF13B002 /* Pods_macOSDFULibrary_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_macOSDFULibrary_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03D632E9071295937AFC372131F0336D /* SecureDFUControlPoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureDFUControlPoint.swift; sourceTree = "<group>"; };
 		04FFD41286B7CF82D97294E01BC9113C /* LegacyDFUService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegacyDFUService.swift; sourceTree = "<group>"; };
 		07E3623AEDB4B5AFD35E16D05442F170 /* iOSDFULibrary-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "iOSDFULibrary-iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -216,7 +216,7 @@
 		20A6432E296DABF03E2EB8B142B79F35 /* iOSDFULibrary-macOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; name = "iOSDFULibrary-macOS.modulemap"; path = "../iOSDFULibrary-macOS/iOSDFULibrary-macOS.modulemap"; sourceTree = "<group>"; };
 		22F930F63EF7477F0B99ADD35CB82EB9 /* LegacyDFUPeripheralDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LegacyDFUPeripheralDelegate.swift; sourceTree = "<group>"; };
 		275FFF2CC345951CBD05EE0F248D280C /* FileManager+ZIP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "FileManager+ZIP.swift"; path = "Sources/ZIPFoundation/FileManager+ZIP.swift"; sourceTree = "<group>"; };
-		293E8767C7348B54C3BD3B8DF431B7A5 /* Pods_iOSDFULibrary_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_iOSDFULibrary_Tests.framework; path = "Pods-iOSDFULibrary_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		293E8767C7348B54C3BD3B8DF431B7A5 /* Pods_iOSDFULibrary_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSDFULibrary_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C723040DECD495E1AAC81F5AA497C97 /* Pods-macOSDFULibrary_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-macOSDFULibrary_Example.release.xcconfig"; sourceTree = "<group>"; };
 		2E52E97E957D7D029A8DF57B9E634832 /* DFUStarterPeripheral.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUStarterPeripheral.swift; sourceTree = "<group>"; };
 		3387AA2AB8717EEFE511617CE7D55616 /* Data+Serialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Serialization.swift"; path = "Sources/ZIPFoundation/Data+Serialization.swift"; sourceTree = "<group>"; };
@@ -233,13 +233,13 @@
 		4481F071D62B984DEB3EB9399CA4E74E /* DFUStreamHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUStreamHex.swift; sourceTree = "<group>"; };
 		4483A2CE744F48588B4D506DBEF7F250 /* DFUServiceController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUServiceController.swift; sourceTree = "<group>"; };
 		44C80322FD2FD584FE3026B2958F84A3 /* Pods-iOSDFULibrary_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-iOSDFULibrary_Example-frameworks.sh"; sourceTree = "<group>"; };
-		4DAE4CA690F46F73313173F276D52DBC /* iOSDFULibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = iOSDFULibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		4DAE4CA690F46F73313173F276D52DBC /* iOSDFULibrary.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = iOSDFULibrary.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		50F1B401A63FC807B11D6C47DA277688 /* SecureDFUExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureDFUExecutor.swift; sourceTree = "<group>"; };
 		57BC41850D4BDB49CD82D03A7D06EE9D /* SecureDFUService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureDFUService.swift; sourceTree = "<group>"; };
 		59098759DE2EA56152B8B35FAF9D65F8 /* DFUFirmware.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUFirmware.swift; sourceTree = "<group>"; };
 		59F7D6CA361F44101B9A79318C1B29CF /* Pods-iOSDFULibrary_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-iOSDFULibrary_Tests-Info.plist"; sourceTree = "<group>"; };
 		5F01BE906F5D3CA8A0DF6BBF539C9E76 /* DFUStreamZip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUStreamZip.swift; sourceTree = "<group>"; };
-		5F511BDF6BAF5FE9F5935ACD2B1870F0 /* Pods_iOSDFULibrary_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_iOSDFULibrary_Example.framework; path = "Pods-iOSDFULibrary_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F511BDF6BAF5FE9F5935ACD2B1870F0 /* Pods_iOSDFULibrary_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSDFULibrary_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6085DCA4586255401B60695D5927050D /* Pods-iOSDFULibrary_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-iOSDFULibrary_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		6407D43FC0B15AABD203A078E753441B /* DFUCharacteristic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUCharacteristic.swift; sourceTree = "<group>"; };
 		69D3A066AEB0DEB08695962B9831B80B /* DFUControlPoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUControlPoint.swift; sourceTree = "<group>"; };
@@ -250,7 +250,7 @@
 		6CFC421A1A470F2CC951B9918A2F6667 /* Pods-iOSDFULibrary_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-iOSDFULibrary_Example-umbrella.h"; sourceTree = "<group>"; };
 		6FAC228069346CE04FF74C0A61AB5CBD /* Pods-macOSDFULibrary_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-macOSDFULibrary_Example-frameworks.sh"; sourceTree = "<group>"; };
 		7180BAF326DCF1EC92FD426EA99303A8 /* DFUStreamBin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUStreamBin.swift; sourceTree = "<group>"; };
-		7186CA92E6615BDC8A925FE560577AFA /* iOSDFULibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = iOSDFULibrary.framework; path = "iOSDFULibrary-macOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7186CA92E6615BDC8A925FE560577AFA /* iOSDFULibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = iOSDFULibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7875B8EDC4FED09D7D6F539E6118346C /* ZIPFoundation-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "ZIPFoundation-macOS.debug.xcconfig"; path = "../ZIPFoundation-macOS/ZIPFoundation-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		7996F3AB192EF9745CBACBAB1E956DFA /* Pods-macOSDFULibrary_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-macOSDFULibrary_Example.modulemap"; sourceTree = "<group>"; };
 		7D3E6FDF6CE1FCB41F2B1092C03B9E9D /* DFUUuidHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUUuidHelper.swift; sourceTree = "<group>"; };
@@ -261,7 +261,7 @@
 		890A09B61D0F51EA84B75D5E02FE58D2 /* Pods-macOSDFULibrary_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-macOSDFULibrary_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		8A78DA279BDF810AC17123BDD8F2040B /* iOSDFULibrary-macOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "iOSDFULibrary-macOS-prefix.pch"; path = "../iOSDFULibrary-macOS/iOSDFULibrary-macOS-prefix.pch"; sourceTree = "<group>"; };
 		8AD81CC38AD9E17564E46ABB01E637EA /* Pods-iOSDFULibrary_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-iOSDFULibrary_Tests-umbrella.h"; sourceTree = "<group>"; };
-		8B6DAC4ABC154048188F2C99BEDE52FE /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		8B6DAC4ABC154048188F2C99BEDE52FE /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		8B8EFB23982285669E0884654DE0E5A0 /* SoftdeviceBootloaderInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SoftdeviceBootloaderInfo.swift; sourceTree = "<group>"; };
 		8BC7F0C7A0703F6C06C45C72E642D2E8 /* ZipArchive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ZipArchive.swift; sourceTree = "<group>"; };
 		8E800E67CF9CCC18A18002A7575780EA /* Pods-macOSDFULibrary_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-macOSDFULibrary_Example-umbrella.h"; sourceTree = "<group>"; };
@@ -270,10 +270,10 @@
 		95AE1FF4DB84A6C0C511261F30EF7A55 /* SecureDFUServiceInitiator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureDFUServiceInitiator.swift; sourceTree = "<group>"; };
 		990BB505FAC45A418FB7BEF924C69F59 /* DFUServiceSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUServiceSelector.swift; sourceTree = "<group>"; };
 		9B94890E1EFC954F0887F0775A0FD505 /* Data+Compression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Data+Compression.swift"; path = "Sources/ZIPFoundation/Data+Compression.swift"; sourceTree = "<group>"; };
-		9BC1F246F7EF310C62A17B761E63BACE /* ZIPFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ZIPFoundation.framework; path = "ZIPFoundation-macOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9BC1F246F7EF310C62A17B761E63BACE /* ZIPFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZIPFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9DE3F8186A2C9281B708844560549F05 /* Pods-iOSDFULibrary_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-iOSDFULibrary_Example.modulemap"; sourceTree = "<group>"; };
-		9EF83BCCEFAE08B31095A9B245E76A58 /* ZIPFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ZIPFoundation.framework; path = "ZIPFoundation-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9EF83BCCEFAE08B31095A9B245E76A58 /* ZIPFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZIPFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FE05FE0633A698175EF9BCDD9CC115E /* Double.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		A2137A03A262376A656C143F9A78E7AC /* ZIPFoundation-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ZIPFoundation-iOS-umbrella.h"; sourceTree = "<group>"; };
 		A7297D6E3E04FA9451CA42A5F639E10E /* ZIPFoundation-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ZIPFoundation-iOS-prefix.pch"; sourceTree = "<group>"; };
@@ -299,7 +299,7 @@
 		CA323948D85FA0E507B527490F99910E /* iOSDFULibrary-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "iOSDFULibrary-iOS-dummy.m"; sourceTree = "<group>"; };
 		CD261474D662E14B2BDDBA61BA9DD534 /* Pods-iOSDFULibrary_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-iOSDFULibrary_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		CD4CD31BA2F18B60F27B1CB65C362BE0 /* iOSDFULibrary-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "iOSDFULibrary-macOS.debug.xcconfig"; path = "../iOSDFULibrary-macOS/iOSDFULibrary-macOS.debug.xcconfig"; sourceTree = "<group>"; };
-		D5E133000ABA8F10FA6F13CB0871577E /* iOSDFULibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = iOSDFULibrary.framework; path = "iOSDFULibrary-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5E133000ABA8F10FA6F13CB0871577E /* iOSDFULibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = iOSDFULibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6F12E85611B24B18AF32B3A5354ABB9 /* Entry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Entry.swift; path = Sources/ZIPFoundation/Entry.swift; sourceTree = "<group>"; };
 		D8A2A5EBB11101A40DEA25F7E5FD9FDF /* DFUPeripheralDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DFUPeripheralDelegate.swift; sourceTree = "<group>"; };
 		DC0A2CEB17D3AF5A354EAA9FE1A2637E /* iOSDFULibrary-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "iOSDFULibrary-iOS.modulemap"; sourceTree = "<group>"; };
@@ -314,7 +314,7 @@
 		E9DDA9C0E99A903A277CD00AE1DEECD6 /* iOSDFULibrary-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "iOSDFULibrary-iOS-umbrella.h"; sourceTree = "<group>"; };
 		EAAAE6FF3B53F0BBAE2BC3D68A2BB8E1 /* Pods-macOSDFULibrary_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-macOSDFULibrary_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		EB8F5587A24941C91702E23924DCF99D /* Pods-iOSDFULibrary_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-iOSDFULibrary_Tests-dummy.m"; sourceTree = "<group>"; };
-		EBF0BE39DE36E872E9BAEBE726B544EA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		EBF0BE39DE36E872E9BAEBE726B544EA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		EE200604B499B89785191AA8348B49FB /* LoggerHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoggerHelper.swift; sourceTree = "<group>"; };
 		F884612E02A237E5730474BB08CE5C76 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		FA7938C19E625B145056CBFFBD5CECA5 /* iOSDFULibrary-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "iOSDFULibrary-macOS.release.xcconfig"; path = "../iOSDFULibrary-macOS/iOSDFULibrary-macOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -391,7 +391,6 @@
 				3A13EAD04597F4BE9B581ADAD00D905F /* ManifestFirmwareInfo.swift */,
 				8B8EFB23982285669E0884654DE0E5A0 /* SoftdeviceBootloaderInfo.swift */,
 			);
-			name = Manifest;
 			path = Manifest;
 			sourceTree = "<group>";
 		};
@@ -400,7 +399,6 @@
 			children = (
 				AC393AAF7F1210B74EEE3BA1C665D9B7 /* IntelHex2BinConverter.swift */,
 			);
-			name = HexToBinConverter;
 			path = HexToBinConverter;
 			sourceTree = "<group>";
 		};
@@ -412,7 +410,6 @@
 				E947BAC8EC1BBD958AE8656C1672CA81 /* Peripheral */,
 				F981912FB0A5124D25DC25400C34D4DC /* Services */,
 			);
-			name = SecureDFU;
 			path = SecureDFU;
 			sourceTree = "<group>";
 		};
@@ -443,7 +440,6 @@
 			children = (
 				04FFD41286B7CF82D97294E01BC9113C /* LegacyDFUService.swift */,
 			);
-			name = Services;
 			path = Services;
 			sourceTree = "<group>";
 		};
@@ -455,7 +451,6 @@
 				A337C74595816C387627ACA81B85CB96 /* Peripherals */,
 				296B96EA3F6A110D6AC34404AD40E805 /* Services */,
 			);
-			name = LegacyDFU;
 			path = LegacyDFU;
 			sourceTree = "<group>";
 		};
@@ -474,7 +469,6 @@
 				03D632E9071295937AFC372131F0336D /* SecureDFUControlPoint.swift */,
 				1208D8CC8788E6789527D90284D13395 /* SecureDFUPacket.swift */,
 			);
-			name = Characteristics;
 			path = Characteristics;
 			sourceTree = "<group>";
 		};
@@ -520,7 +514,6 @@
 				50F1B401A63FC807B11D6C47DA277688 /* SecureDFUExecutor.swift */,
 				95AE1FF4DB84A6C0C511261F30EF7A55 /* SecureDFUServiceInitiator.swift */,
 			);
-			name = DFU;
 			path = DFU;
 			sourceTree = "<group>";
 		};
@@ -563,7 +556,6 @@
 				E2104270E715BF45073CE74BDF938C41 /* LegacyDFUPeripheral.swift */,
 				22F930F63EF7477F0B99ADD35CB82EB9 /* LegacyDFUPeripheralDelegate.swift */,
 			);
-			name = Peripherals;
 			path = Peripherals;
 			sourceTree = "<group>";
 		};
@@ -589,7 +581,6 @@
 			children = (
 				59098759DE2EA56152B8B35FAF9D65F8 /* DFUFirmware.swift */,
 			);
-			name = Firmware;
 			path = Firmware;
 			sourceTree = "<group>";
 		};
@@ -646,7 +637,6 @@
 				D8A2A5EBB11101A40DEA25F7E5FD9FDF /* DFUPeripheralDelegate.swift */,
 				14D437C75D6D92082FB1B9271F209C69 /* DFUService.swift */,
 			);
-			name = GenericDFU;
 			path = GenericDFU;
 			sourceTree = "<group>";
 		};
@@ -656,7 +646,6 @@
 				990BB505FAC45A418FB7BEF924C69F59 /* DFUServiceSelector.swift */,
 				2E52E97E957D7D029A8DF57B9E634832 /* DFUStarterPeripheral.swift */,
 			);
-			name = DFUSelector;
 			path = DFUSelector;
 			sourceTree = "<group>";
 		};
@@ -673,7 +662,6 @@
 				275FFF2CC345951CBD05EE0F248D280C /* FileManager+ZIP.swift */,
 				25A31513A833503473C6FF62A7DD10A6 /* Support Files */,
 			);
-			name = ZIPFoundation;
 			path = ZIPFoundation;
 			sourceTree = "<group>";
 		};
@@ -715,7 +703,6 @@
 				B75A32C78BBB85FF4A963DD504B86EC1 /* DFUPacket.swift */,
 				1D770713DBF7FE70675F76750A167C02 /* DFUVersion.swift */,
 			);
-			name = Characteristics;
 			path = Characteristics;
 			sourceTree = "<group>";
 		};
@@ -747,7 +734,6 @@
 				A92DC3C4C826ACD5D7D6E90208E5F715 /* SecureDFUPeripheral.swift */,
 				92F0AC92DC6DE399DB86A1879CD12287 /* SecureDFUPeripheralDelegate.swift */,
 			);
-			name = Peripheral;
 			path = Peripheral;
 			sourceTree = "<group>";
 		};
@@ -766,7 +752,6 @@
 			children = (
 				06F44069A73084A1F704653551D269A1 /* Manifest */,
 			);
-			name = DFUPackage;
 			path = DFUPackage;
 			sourceTree = "<group>";
 		};
@@ -784,7 +769,6 @@
 				3F701B6F7B00E8F12B5D243C07DB7258 /* LoggerDelegate.swift */,
 				EE200604B499B89785191AA8348B49FB /* LoggerHelper.swift */,
 			);
-			name = Logging;
 			path = Logging;
 			sourceTree = "<group>";
 		};
@@ -794,7 +778,6 @@
 				6CE7747EED0FE0207877DFFC2B1068BA /* LegacyDFUExecutor.swift */,
 				B8D70DBC35E7D031526F2620D3D4F773 /* LegacyDFUServiceInitiator.swift */,
 			);
-			name = DFU;
 			path = DFU;
 			sourceTree = "<group>";
 		};
@@ -806,7 +789,6 @@
 				4481F071D62B984DEB3EB9399CA4E74E /* DFUStreamHex.swift */,
 				5F01BE906F5D3CA8A0DF6BBF539C9E76 /* DFUStreamZip.swift */,
 			);
-			name = Streams;
 			path = Streams;
 			sourceTree = "<group>";
 		};
@@ -815,7 +797,6 @@
 			children = (
 				57BC41850D4BDB49CD82D03A7D06EE9D /* SecureDFUService.swift */,
 			);
-			name = Services;
 			path = Services;
 			sourceTree = "<group>";
 		};
@@ -1022,7 +1003,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1250;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1385,7 +1366,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7875B8EDC4FED09D7D6F539E6118346C /* ZIPFoundation-macOS.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1420,7 +1400,6 @@
 			baseConfigurationReference = 2C723040DECD495E1AAC81F5AA497C97 /* Pods-macOSDFULibrary_Example.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1455,7 +1434,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FA7938C19E625B145056CBFFBD5CECA5 /* iOSDFULibrary-macOS.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1555,7 +1533,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E133B98FF4991CAD90D04DFDB2917CEA /* ZIPFoundation-macOS.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1590,7 +1567,6 @@
 			baseConfigurationReference = 890A09B61D0F51EA84B75D5E02FE58D2 /* Pods-macOSDFULibrary_Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1625,7 +1601,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4CD31BA2F18B60F27B1CB65C362BE0 /* iOSDFULibrary-macOS.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1749,6 +1724,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1777,8 +1753,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};
@@ -1874,6 +1849,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-iOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-macOS.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/iOSDFULibrary.xcodeproj/project.pbxproj
+++ b/Example/iOSDFULibrary.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					37E4ADEF2008CA1C005464DD = {

--- a/Example/iOSDFULibrary.xcodeproj/project.pbxproj
+++ b/Example/iOSDFULibrary.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -673,7 +673,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nordicsemi.macOS-DFU-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Example/iOSDFULibrary.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-Example.xcscheme
+++ b/Example/iOSDFULibrary.xcodeproj/xcshareddata/xcschemes/iOSDFULibrary-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/iOSDFULibrary/DFU Test Performer/nRF52840TestSet.swift
+++ b/Example/iOSDFULibrary/DFU Test Performer/nRF52840TestSet.swift
@@ -41,12 +41,12 @@ class nRF52840TestSet: DFUTestSet {
             // This is not something a customer would do, but with this trick it is possible to test DFU on older SDKs.
             
             // Files with 'bl' must be uploaded in the correct order, as each next version must have bl_version greater then the last one.
-  //          (DFUFirmware.from(zip: "nrf52840_sdk_13_app"               , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating app",          FilterBy.name("DFU3A13")),
+            (DFUFirmware.from(zip: "nrf52840_sdk_13_app"               , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating app",          FilterBy.name("DFU3A13")),
             // The following steps may be removed without any harm if more SDKs are added.
-  //          (DFUFirmware.from(zip: "nrf52840_sdk_13_sd"                , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD only",      FilterBy.name("DFU3A13")),
-  //          (DFUFirmware.from(zip: "nrf52840_sdk_13_sd_bl_1"           , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD+BL",        FilterBy.name("DFU3A13")),
-  //          (DFUFirmware.from(zip: "nrf52840_sdk_13_bl_2"              , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating BL only",      FilterBy.name("DFU3A13")),
-  //          (DFUFirmware.from(zip: "nrf52840_sdk_13_sd_bl_app_3"       , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD+BL+App",    FilterBy.name("DFU3A13")),
+            (DFUFirmware.from(zip: "nrf52840_sdk_13_sd"                , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD only",      FilterBy.name("DFU3A13")),
+            (DFUFirmware.from(zip: "nrf52840_sdk_13_sd_bl_1"           , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD+BL",        FilterBy.name("DFU3A13")),
+            (DFUFirmware.from(zip: "nrf52840_sdk_13_bl_2"              , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating BL only",      FilterBy.name("DFU3A13")),
+            (DFUFirmware.from(zip: "nrf52840_sdk_13_sd_bl_app_3"       , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Updating SD+BL+App",    FilterBy.name("DFU3A13")),
             
             // Updating to SDK 14. SDK 14 uses the same SD s140 5.0.0-2.alpha
             (DFUFirmware.from(zip: "nrf52840_sdk_13_to_14_all_in_one"  , locatedIn:  "Firmwares/nRF52840"), nil, nil, "Upgrading to SDK 14",   FilterBy.name("DFU3A14")),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 //
 // The `swift-tools-version` declares the minimum version of Swift required to
 // build this package. Do not remove it.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 //
 // The `swift-tools-version` declares the minimum version of Swift required to
 // build this package. Do not remove it.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ A library for both iOS and Android that is based on this library is available fo
 
 ### Xamarin
 
-Simple binding libraries for iOS and Android are available on nuget:
-[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+Simple binding library for iOS is available on nuget:
 [xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ An unofficial library for both iOS and Android that is based on this library is 
 A library for both iOS and Android that is based on this library is available for Flutter: 
 [flutter-nordic-dfu](https://github.com/fengqiangboy/flutter-nordic-dfu) 
 
+### Xamarin
+
+Simple binding libraries for iOS and Android are available on nuget:
+[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+[xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
+
 ---
 
 ### Resources

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A library for both iOS and Android that is based on this library is available fo
 ### Xamarin
 
 Simple binding library for iOS is available on nuget:
-[xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
+[Laerdal.Xamarin.Dfu.iOS](https://www.nuget.org/packages/Laerdal.Xamarin.Dfu.iOS/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 - Create/Update your **Podfile** with the following contents
 
-    ```
-    target 'YourAppTargetName' do
-        use_frameworks!
-        pod 'iOSDFULibrary'
-    end
-    ```
+```ruby
+target 'YourAppTargetName' do
+    use_frameworks!
+    pod 'iOSDFULibrary'
+end
+```
 
 - Install dependencies
 
-    ```
-    pod install
-    ```
+```ruby
+pod install
+```
 
 - Open the newly created `.xcworkspace`
 
@@ -31,15 +31,15 @@
 
 - Create a new **Cartfile** in your project's root with the following contents
 
-    ```
-    github "NordicSemiconductor/IOS-Pods-DFU-Library" ~> x.y //Replace x.y with your required version
-    ```
+```ogld
+github "NordicSemiconductor/IOS-Pods-DFU-Library" ~> x.y //Replace x.y with your required version
+```
 
 - Build with carthage
 
-    ```
-    carthage update --platform iOS //also OSX platform is available for macOS builds
-    ```
+```sh
+carthage update --platform iOS //also OSX platform is available for macOS builds
+```
 
 - Carthage will build the **iOSDFULibrary.framework** and **ZipFramework.framework** files in **Carthage/Build/**, 
 you may now copy all those files to your project and use the library, additionally, carthade also builds **\*.dsym** files 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ if you need to resymbolicate crash logs. you may want to keep those files bundle
 **For Swift Package Manager:**
 
 ```swift
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 ### Changelog
+- **4.9.0**
+   - ZIPFoundation version set to 0.9.11.
+   - Migration to Swift 5.3.
+   - Improvement: Reconnection timeout improvements (#386).
+   - Improvement: Asynchronous firmware provider in the sample app (#387).
+   
 - **4.8.0**
    - Feature: Option to force scanning for Legacy DFU bootloader after jumping using Buttonless Service (#374).
    - Feature: Option to set connection timeout (#369).

--- a/documentation.md
+++ b/documentation.md
@@ -33,7 +33,7 @@ In case of any communication error the peripheral device will never be bricked. 
     Support for the Bluetooth 4.0 technology is required.
 * **nRF5x device for testing.**
 
-   A nRF5x Series device is required to test the working solution. If your final product is not available, use the nRF51 DK, which you can find [here](http://www.nordicsemi.com/eng/Products/nRF51-DK "nRF51 DK") or [here](http://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK "nRF52 DK").
+   A nRF5x Series device is required to test the working solution. If your final product is not available, use the nRF5x DK, which you can find [here](http://www.nordicsemi.com/eng/Products/nRF51-DK "nRF51 DK") or [here](http://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK "nRF52 DK").
 
 ### Integration
 

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -15,7 +15,8 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'
-  s.watchos.deployment_target = '5.0'
+  s.tvos.deployment_target = '11.0'
+  s.watchos.deployment_target = '4.0'
 
   s.source_files = 'iOSDFULibrary/Classes/**/*'
 

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -11,7 +11,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   s.authors          = { "Aleksander Nowakowski" => "aleksander.nowakowski@nordicsemi.no" }
   s.source           = { :git => "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/nordictweets'
-  s.swift_versions   = ['4.2', '5.0', '5.1', '5.2', '5.3']
+  s.swift_versions   = ['4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -15,6 +15,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'
+  s.watchos.deployment_target = '5.0'
 
   s.source_files = 'iOSDFULibrary/Classes/**/*'
 

--- a/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
@@ -66,7 +66,7 @@ import CoreBluetooth
  
  More: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
  */
-@objc public protocol DFUPeripheralSelectorDelegate : class {
+@objc public protocol DFUPeripheralSelectorDelegate: AnyObject {
     
     /**
      Returns whether the given peripheral is a device in DFU Bootloader mode.

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift
@@ -250,6 +250,9 @@ import CoreBluetooth
     /**
      If `alternativeAdvertisingNameEnabled` is `true` then this specifies the
      alternative name to use. If nil (default) then a random name is generated.
+     
+     The maximum length of the alertnative advertising name is 20 bytes.
+     Longer name will be trundated. UTF-8 characters can be cut in the middle.
      */
     @objc public var alternativeAdvertisingName: String? = nil
     

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -32,7 +32,7 @@ import CoreBluetooth
 
 typealias DelegateCallback = (DFUServiceDelegate) -> Void
 
-internal protocol BaseExecutorAPI : class, DFUController {
+internal protocol BaseExecutorAPI: AnyObject, DFUController {
     
     /**
      Starts the DFU operation.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -117,7 +117,9 @@ extension BaseDFUExecutor {
     
     func error(_ error: DFUError, didOccurWithMessage message: String) {
         if error == .bluetoothDisabled {
-            delegate{ $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message) }
+            delegate {
+                $0.dfuError(.bluetoothDisabled, didOccurWithMessage: message)                
+            }
             // Release the cyclic reference.
             peripheral.destroy()
             return

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -101,8 +101,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     internal let experimentalButtonlessServiceInSecureDfuEnabled: Bool
     /// Default error callback.
     internal var defaultErrorCallback: ErrorCallback {
-        return { (error, message) in
-            self.delegate?.error(error, didOccurWithMessage: message)
+        return { [weak self] error, message in
+            self?.delegate?.error(error, didOccurWithMessage: message)
         }
     }
 
@@ -155,9 +155,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         }
         self.peripheral = peripheral
         
-        if peripheral.state != .connected {
-            connect()
-        } else {
+        switch peripheral.state {
+        case .connected:
             let name = peripheral.name ?? "Unknown device"
             logger.i("Connected to \(name)")
             
@@ -171,6 +170,8 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
                 // Let's discover DFU services.
                 discoverServices()
             }
+        default:
+            connect()
         }
     }
     
@@ -239,10 +240,11 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             stateAsString = "Unknown"
         }
         logger.d("[Callback] Central Manager did update state to: \(stateAsString)")
-        if central.state == .poweredOn {
+        switch central.state {
+        case .poweredOn:
             // We are now ready to rumble!
             start()
-        } else {
+        default:
             // The device has been already disconnected if it was connected.
             delegate?.error(.bluetoothDisabled, didOccurWithMessage: "Bluetooth adapter powered off")
             destroy()
@@ -339,11 +341,10 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     // MARK: - Peripheral Delegate methods
     
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        guard error == nil else {
+        if let error = error {
             logger.e("Services discovery failed")
-            logger.e(error!)
-            delegate?.error(.serviceDiscoveryFailed, didOccurWithMessage:
-                "Services discovery failed")
+            logger.e(error)
+            delegate?.error(.serviceDiscoveryFailed, didOccurWithMessage: "Services discovery failed")
             return
         }
         
@@ -370,8 +371,7 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             logger.d("Did you connect to the correct target? It might be that the previous services were cached: toggle Bluetooth from iOS settings to clear cache. Also, ensure the device contains the Service Changed characteristic")
             
             // The device does not support DFU, nor buttonless jump
-            delegate?.error(.deviceNotSupported, didOccurWithMessage:
-                "DFU Service not found")
+            delegate?.error(.deviceNotSupported, didOccurWithMessage: "DFU Service not found")
             return
         }
         // A DFU service was found, congratulations!
@@ -409,7 +409,7 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
      This method should reset the device, preferably switching it to application mode.
      */
     func resetDevice() {
-        if peripheral != nil && peripheral!.state != .disconnected {
+        if let peripheral = peripheral, peripheral.state != .disconnected {
             disconnect()
         } else {
             peripheralDidDisconnect()
@@ -424,27 +424,17 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
      - returns: A `DFUService` type if a DFU service has been found, or `nil` if
                 services are `nil` or the list does not contain any supported DFU Service.
      */
-    private func findDfuService(in services:[CBService]?) -> CBService? {
-        if let services = services {
-            for service in services {
-                // Skip the experimental Buttonless DFU Service if this feature wasn't enabled.
-                if experimentalButtonlessServiceInSecureDfuEnabled && service.matches(uuid: uuidHelper.buttonlessExperimentalService) {
-                    // The experimental Buttonless DFU Service for Secure DFU has been found.
-                    return service
-                }
-
-                if service.matches(uuid: uuidHelper.secureDFUService) {
-                    // Secure DFU Service has been found.
-                    return service
-                }
-
-                if service.matches(uuid: uuidHelper.legacyDFUService) {
-                    // Legacy DFU Service has been found.
-                    return service
-                }
-            }
+    private func findDfuService(in services: [CBService]?) -> CBService? {
+        return services?.first { service in
+            // The experimental Buttonless DFU Service for Secure DFU has been found.
+            // Skip the experimental Buttonless DFU Service if this feature wasn't enabled.
+            (experimentalButtonlessServiceInSecureDfuEnabled &&
+                service.matches(uuid: uuidHelper.buttonlessExperimentalService)) ||
+            // Secure DFU Service has been found.
+            service.matches(uuid: uuidHelper.secureDFUService) ||
+            // Legacy DFU Service has been found.
+            service.matches(uuid: uuidHelper.legacyDFUService)
         }
-        return nil
     }
     
     /**
@@ -651,7 +641,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
             // This part of firmware has been successfully sent.
             
             // Check if there is another part to be sent.
-            if (delegate?.peripheralDidDisconnectAfterFirmwarePartSent() ?? false) {
+            if delegate?.peripheralDidDisconnectAfterFirmwarePartSent() == true {
                 // As we are already in bootloader mode, the peripheral set
                 // may be reused for sending a second part.
                 connectOrSwitchToNewPeripheral(after: 15.0)
@@ -695,9 +685,9 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
         // With that flag equal to true, the library will try to connect to the
         // same device (with a short timeout), and if that fails, will try to
         // scan for a new address using `DFUPeripheralSelector`.
-        connect(withTimeout: timeout) { [unowned self] in
+        connect(withTimeout: timeout) { [weak self] in
             // Scan for a new device and connect to it.
-            self.switchToNewPeripheralAndConnect()
+            self?.switchToNewPeripheralAndConnect()
         }
     }
     

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-internal protocol BaseDFUPeripheralAPI : class, DFUController {
+internal protocol BaseDFUPeripheralAPI: AnyObject, DFUController {
     
     /**
      This method starts DFU process for given peripheral. If the peripheral is

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -161,16 +161,15 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
             let name = peripheral.name ?? "Unknown device"
             logger.i("Connected to \(name)")
             
-            let dfuService = findDfuService(in: peripheral.services)
-            if dfuService == nil {
+            if let dfuService = findDfuService(in: peripheral.services) {
+                // A DFU service was found, congratulations!
+                logger.i("Services discovered")
+                peripheralDidDiscoverDfuService(dfuService)
+            } else {
                 // DFU service has not been found, but it doesn't matter it's not
                 // there. Perhaps the user's application didn't discover it.
                 // Let's discover DFU services.
                 discoverServices()
-            } else {
-                // A DFU service was found, congratulations!
-                logger.i("Services discovered")
-                peripheralDidDiscoverDfuService(dfuService!)
             }
         }
     }
@@ -181,13 +180,14 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
     }
     
     func disconnect() {
-        if peripheral!.state == .connected {
+        guard let peripheral = peripheral else { return }
+        if peripheral.state == .connected {
             logger.v("Disconnecting...")
         } else {
             logger.v("Cancelling connection...")
         }
         logger.d("centralManager.cancelPeripheralConnection(peripheral)")
-        centralManager.cancelPeripheralConnection(peripheral!)
+        centralManager.cancelPeripheralConnection(peripheral)
     }
     
     func destroy() {
@@ -703,7 +703,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
     
     func switchToNewPeripheralAndConnect() {
         // Release the previous peripheral.
-        peripheral!.delegate = nil
+        peripheral?.delegate = nil
         peripheral = nil
         cleanUp()
         

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -654,7 +654,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
             if (delegate?.peripheralDidDisconnectAfterFirmwarePartSent() ?? false) {
                 // As we are already in bootloader mode, the peripheral set
                 // may be reused for sending a second part.
-                connectOrSwitchToNewPeripheral(after: 3.0)
+                connectOrSwitchToNewPeripheral(after: 15.0)
             } else {
                 // Upload is completed.
                 // Peripheral has been destroyed and state is now .completed.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
@@ -28,7 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-internal protocol BasePeripheralDelegate : class {
+internal protocol BasePeripheralDelegate: AnyObject {
     
     /**
      Method called when the iDevice failed to connect to the given peripheral.

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
@@ -69,10 +69,10 @@ internal class DFUPacket: DFUCharacteristic {
         // Get the peripheral object
         let peripheral = characteristic.service.peripheral
         
-        var data = Data(capacity: 12)
-        data += size.softdevice.littleEndian
-        data += size.bootloader.littleEndian
-        data += size.application.littleEndian
+        let data = Data()
+            + size.softdevice.littleEndian
+            + size.bootloader.littleEndian
+            + size.application.littleEndian
 
         let packetUUID = characteristic.uuid.uuidString
         
@@ -91,9 +91,8 @@ internal class DFUPacket: DFUCharacteristic {
         // Get the peripheral object.
         let peripheral = characteristic.service.peripheral
         
-        var data = Data(capacity: 4)
-        data += size.application.littleEndian
-
+        let data = Data() + size.application.littleEndian
+        
         let packetUUID = characteristic.uuid.uuidString
 
         logger.v("Writing image size (\(size.application)b) to characteristic \(packetUUID)...")
@@ -167,14 +166,15 @@ internal class DFUPacket: DFUCharacteristic {
             lastTime = startTime
             
             // Notify progress delegate that upload has started (0%).
-            queue.async(execute: {
+            queue.async {
                 progress?.dfuProgressDidChange(
                     for:   firmware.currentPart,
                     outOf: firmware.parts,
                     to:    0,
                     currentSpeedBytesPerSecond: 0.0,
-                    avgSpeedBytesPerSecond:     0.0)
-            })
+                    avgSpeedBytesPerSecond:     0.0
+                )
+            }
         }
         
         while packetsToSendNow > 0 {
@@ -212,14 +212,15 @@ internal class DFUPacket: DFUCharacteristic {
                 lastTime = now
                 bytesSentSinceProgessNotification = bytesSent
                 
-                queue.async(execute: {
+                queue.async {
                     progress?.dfuProgressDidChange(
                         for:   firmware.currentPart,
                         outOf: firmware.parts,
                         to:    Int(currentProgress),
                         currentSpeedBytesPerSecond: currentSpeed,
-                        avgSpeedBytesPerSecond:     avgSpeed)
-                })
+                        avgSpeedBytesPerSecond:     avgSpeed
+                    )
+                }
                 progressReported = currentProgress
             }
         }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -97,7 +97,7 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
         logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
         
         // Validate data length
-        if data == nil || data!.count != 2 {
+        if data?.count != 2 {
             logger.w("Invalid value: 2 bytes expected")
             report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
             return

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -86,27 +86,28 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
             return
         }
 
-        if error != nil {
+        if let error = error {
             logger.e("Reading DFU Version characteristic failed")
-            logger.e(error!)
+            logger.e(error)
             report?(.readingVersionFailed, "Reading DFU Version characteristic failed")
-        } else {
-            let data = characteristic.value
-            logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
-            
-            // Validate data length
-            if data == nil || data!.count != 2 {
-                logger.w("Invalid value: 2 bytes expected")
-                report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
-                return
-            }
-            
-            // Read major and minor
-            let minor: UInt8 = data![0]
-            let major: UInt8 = data![1]
-            
-            logger.a("Version number read: \(major).\(minor)")
-            success?(major, minor)
+            return
         }
+        
+        let data = characteristic.value
+        logger.i("Read Response received from \(characteristic.uuid.uuidString), value\(data != nil && data!.count > 0 ? " (0x): " + data!.hexString : ": 0 bytes")")
+        
+        // Validate data length
+        if data == nil || data!.count != 2 {
+            logger.w("Invalid value: 2 bytes expected")
+            report?(.readingVersionFailed, "Unsupported DFU Version: \(data != nil && data!.count > 0 ? "0x" + data!.hexString : "no value")")
+            return
+        }
+        
+        // Read major and minor
+        let minor: UInt8 = data![0]
+        let major: UInt8 = data![1]
+        
+        logger.a("Version number read: \(major).\(minor)")
+        success?(major, minor)
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/DFU/LegacyDFUExecutor.swift
@@ -41,7 +41,7 @@ internal class LegacyDFUExecutor : DFUExecutor, LegacyDFUPeripheralDelegate {
     internal var error      : (error: DFUError, message: String)?
     
     /// Retry counter for peripheral invalid state issue.
-    private let MaxRetryCount = 1
+    private let maxRetryCount = 1
     private var invalidStateRetryCount: Int
     
     // MARK: - Initialization
@@ -52,7 +52,7 @@ internal class LegacyDFUExecutor : DFUExecutor, LegacyDFUPeripheralDelegate {
         self.peripheral = LegacyDFUPeripheral(initiator, logger)
         self.firmware   = initiator.file!
         
-        self.invalidStateRetryCount = MaxRetryCount
+        self.invalidStateRetryCount = maxRetryCount
     }
     
     func start() {

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -88,7 +88,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { (error, message) in
+            onError: { error, message in
                 self.jumpingToBootloader = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }
@@ -219,7 +219,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.sendActivateAndResetRequest(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { (error, message) in
+            onError: { error, message in
                 self.activating = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -44,7 +44,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // characteristic was introduced (SDK 7.0.0). It version exists, and we are not
         // in Application mode, then the Init Packet is required.
         
-        if let version = dfuService!.version {
+        if let version = dfuService?.version {
             // In the application mode we don't know whether init packet is required
             // as the app is indepenrent from the DFU Bootloader.
             let isInApplicationMode = version.major == 0 && version.minor == 1
@@ -59,14 +59,14 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      Enables notifications on DFU Control Point characteristic.
      */
     func enableControlPoint() {
-        dfuService!.enableControlPoint(
+        dfuService?.enableControlPoint(
             onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
     
     override func isInApplicationMode(_ forceDfu: Bool) -> Bool {
-        let applicationMode = dfuService!.isInApplicationMode() ?? !forceDfu
+        let applicationMode = dfuService?.isInApplicationMode() ?? !forceDfu
         
         if applicationMode {
             logger.w("Application with buttonless update found")
@@ -82,9 +82,10 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
                                   with a different address than when in app mode.
      */
     func jumpToBootloader(forceNewAddress: Bool) {
+        guard let dfuService = dfuService else { return }
         jumpingToBootloader = true
-        newAddressExpected = dfuService!.newAddressExpected || forceNewAddress
-        dfuService!.jumpToBootloaderMode(
+        newAddressExpected = dfuService.newAddressExpected || forceNewAddress
+        dfuService.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             onError: { (error, message) in
@@ -108,7 +109,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      - parameter size: The size of all parts of the firmware.
      */
     func sendStartDfu(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize) {
-        dfuService!.sendDfuStart(withFirmwareType: type, andSize: size,
+        dfuService?.sendDfuStart(withFirmwareType: type, andSize: size,
             onSuccess: { self.delegate?.peripheralDidStartDfu() },
             onError: { error, message in
                 if error == .remoteLegacyDFUNotSupported {
@@ -131,6 +132,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
                        Softdevice and Bootloader are 0.
      */
     func sendStartDfu(withFirmwareSize size: DFUFirmwareSize) {
+        guard let dfuService = dfuService else { return }
         logger.v("Switching to DFU v.1")
         
         // Flash operation in DFU Bootloaders from SDK 6.0 and older were too slow
@@ -138,7 +140,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // Also, a 1000ms delay is required before starting sending data.
         slowDfuMode = true
         
-        dfuService!.sendStartDfu(withFirmwareSize: size,
+        dfuService.sendStartDfu(withFirmwareSize: size,
             onSuccess: { self.delegate?.peripheralDidStartDfu() },
             onError: defaultErrorCallback
         )
@@ -151,7 +153,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      - parameter data: Init Packet data.
      */
     func sendInitPacket(_ data: Data) {
-        dfuService!.sendInitPacket(data,
+        dfuService?.sendInitPacket(data,
             onSuccess: { self.delegate?.peripheralDidReceiveInitPacket() },
             onError: defaultErrorCallback
         )
@@ -178,10 +180,10 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
             // Otherwise, the device could send error 6: Operation failed.
             prn = 1
         }
-        dfuService!.sendPacketReceiptNotificationRequest(prn,
+        dfuService?.sendPacketReceiptNotificationRequest(prn,
             onSuccess: {
                 // Now the service is ready to send the firmware.
-                self.dfuService!.sendFirmware(firmware, withDelay: self.slowDfuMode,
+                self.dfuService?.sendFirmware(firmware, withDelay: self.slowDfuMode,
                     andReportProgressTo: progress, on: queue,
                     onSuccess: { self.delegate?.peripheralDidReceiveFirmware() },
                     onError: self.defaultErrorCallback
@@ -196,7 +198,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      On success, the `delegate.peripheralDidVerifyFirmware()` method will be called.
      */
     func validateFirmware() {
-        dfuService!.sendValidateFirmwareRequest(
+        dfuService?.sendValidateFirmwareRequest(
             onSuccess: { self.delegate?.peripheralDidVerifyFirmware() },
             onError: defaultErrorCallback
         )
@@ -206,6 +208,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      Sends the Activate and Reset command to the DFU Control Point characteristic.
      */
     func activateAndReset() {
+        guard let dfuService = dfuService else { return }
         activating = true
         
         // In Legacy DFU the Buttonless service does not increment the device address.
@@ -213,7 +216,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         // and may use incremented MAC address to receive the second part.
         newAddressExpected = true
         
-        dfuService!.sendActivateAndResetRequest(
+        dfuService.sendActivateAndResetRequest(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             onError: { (error, message) in

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -109,7 +109,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      - parameter size: The size of all parts of the firmware.
      */
     func sendStartDfu(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize) {
-        dfuService?.sendDfuStart(withFirmwareType: type, andSize: size,
+        dfuService?.sendStartDfu(withFirmwareType: type, andSize: size,
             onSuccess: { self.delegate?.peripheralDidStartDfu() },
             onError: { error, message in
                 if error == .remoteLegacyDFUNotSupported {

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -105,16 +105,19 @@ import CoreBluetooth
     }
     
     func resume() -> Bool {
-        if !aborted && paused && firmware != nil {
+        guard let dfuPacketCharacteristic = dfuPacketCharacteristic,
+              let firmware = firmware,
+              let progressQueue = progressQueue,
+              !aborted && paused else {
             paused = false
-            // onSuccess and onError callbacks are still kept by dfuControlPointCharacteristic.
-            dfuPacketCharacteristic!.sendNext(packetReceiptNotificationNumber,
-                                              packetsOf: firmware!,
-                                              andReportProgressTo: progressDelegate,
-                                              on: progressQueue!)
             return paused
         }
         paused = false
+        // onSuccess and onError callbacks are still kept by dfuControlPointCharacteristic.
+        dfuPacketCharacteristic.sendNext(packetReceiptNotificationNumber,
+                                          packetsOf: firmware,
+                                          andReportProgressTo: progressDelegate,
+                                          on: progressQueue)
         return paused
     }
     
@@ -123,8 +126,7 @@ import CoreBluetooth
         // When upload has been started and paused, we have to send the Reset command
         // here as the device will not get a Packet Receipt Notification. If it hasn't
         // been paused, the Reset command will be sent after receiving it, on line 380.
-        if paused && firmware != nil {
-            let _report = report!
+        if let _report = report, paused && firmware != nil {
             firmware = nil
             success  = nil
             report   = nil
@@ -192,8 +194,8 @@ import CoreBluetooth
         // - we must be in the DFU mode already (otherwise the device would be useless...).
         // Note: On iOS the Generic Access and Generic Attribute services (nor HID Service)
         //       are not returned during service discovery.
-        let services = service.peripheral.services!
-        if services.count == 1 {
+        let services = service.peripheral.services
+        if services?.count == 1 {
             return false
         }
         // If there are more services than just DFU Service, the state is uncertain.
@@ -226,7 +228,7 @@ import CoreBluetooth
     func enableControlPoint(onSuccess success: @escaping Callback,
                             onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.enableNotifications(onSuccess: success, onError: report)
+            dfuControlPointCharacteristic?.enableNotifications(onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
         }
@@ -239,7 +241,7 @@ import CoreBluetooth
      */
     func jumpToBootloaderMode(onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.jumpToBootloader,
+            dfuControlPointCharacteristic?.send(Request.jumpToBootloader,
                                                 onSuccess: nil, onError: report)
         } else {
             sendReset(onError: report)
@@ -248,8 +250,8 @@ import CoreBluetooth
     
     /**
      This methods sends the Start DFU command with the firmware type to the DFU Control
-     Point characterristic, followed by the sizes of each firware component
-     <softdevice, bootloader, application> (each as UInt32, Little Endian).
+     Point characterristic, followed by the sizes of each firware component:
+     softdevice, bootloader, application (each as UInt32, Little Endian).
      
      - parameter type:    The type of the current firmware part.
      - parameter size:    The sizes of firmware components in the current part.
@@ -257,7 +259,8 @@ import CoreBluetooth
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendDfuStart(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize,
-                      onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                      onSuccess success: @escaping Callback,
+                      onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -276,20 +279,25 @@ import CoreBluetooth
         //    it would receive a response with status = 6 (Operation failed) after sending
         //    some firmware packets. Delay 1 sec seems to work while 600 ms was too short.
         //    The time seems to be required to prepare flash(?).
-        let sendStartDfu = {
+        let sendStartDfu = { [weak self] in
+            guard let self = self else { return }
             // 1. Sends the Start DFU command with the firmware type to DFU Control Point
             //    characteristic.
             // 2. Sends firmware sizes to DFU Packet characteristic.
             // 3. Receives response notification and calls onSuccess or onError.
-            self.dfuControlPointCharacteristic!.send(Request.startDfu(type: type), onSuccess: success) { (error, aMessage) in
-                if error == .remoteLegacyDFUInvalidState {
-                    self.targetPeripheral!.shouldReconnect = true
-                    self.sendReset(onError: report)
-                    return
+            self.dfuControlPointCharacteristic?.send(Request.startDfu(type: type),
+                onSuccess: success,
+                onError: { [weak self] error, message in
+                    guard let self = self else { return }
+                    if error == .remoteLegacyDFUInvalidState {
+                        self.targetPeripheral?.shouldReconnect = true
+                        self.sendReset(onError: report)
+                        return
+                    }
+                    report(error, message)
                 }
-                report(error, aMessage)
-            }
-            self.dfuPacketCharacteristic!.sendFirmwareSize(size)
+            )
+            self.dfuPacketCharacteristic?.sendFirmwareSize(size)
         }
         if version != nil {
             // The legacy DFU bootloader from SDK 7.0+ does not require delay.
@@ -304,15 +312,15 @@ import CoreBluetooth
     
     /**
      This methods sends the old Start DFU command (without the firmware type) to the
-     DFU Control Point characterristic, followed by the application size
-     <application> (UInt32, Little Endian).
+     DFU Control Point characterristic, followed by the application size (UInt32, Little Endian).
      
      - parameter size:    The sizes of firmware components in the current part.
      - parameter success: A callback called when a response with status Success is received.
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendStartDfu(withFirmwareSize size: DFUFirmwareSize,
-                      onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                      onSuccess success: @escaping Callback,
+                      onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -320,21 +328,24 @@ import CoreBluetooth
         
         // See comment in sendDfuStart(withFirmwareType:andSize:onSuccess:onError) above
         logger.d("wait(1000)")
-        queue.asyncAfter(deadline: .now() + .milliseconds(1000)) {
+        queue.asyncAfter(deadline: .now() + .milliseconds(1000)) { [weak self] in
+            guard let self = self else { return }
             // 1. Sends the Start DFU command with the firmware type to the DFU Control Point
             //    characteristic.
             // 2. Sends firmware sizes to the DFU Packet characteristic.
             // 3. Receives response notification and calls onSuccess or onError.
-            self.dfuControlPointCharacteristic!.send(Request.startDfu_v1, onSuccess: success) {
-                (error, aMessage) in
-                if error == .remoteLegacyDFUInvalidState {
-                    self.targetPeripheral!.shouldReconnect = true
-                    self.sendReset(onError: report)
-                    return
-                }
-                report(error, aMessage)
-            }
-            self.dfuPacketCharacteristic!.sendFirmwareSize_v1(size)
+            self.dfuControlPointCharacteristic?.send(Request.startDfu_v1,
+                onSuccess: success,
+                onError: { [weak self] error, message in
+                    guard let self = self else { return }
+                    if error == .remoteLegacyDFUInvalidState {
+                        self.targetPeripheral!.shouldReconnect = true
+                        self.sendReset(onError: report)
+                        return
+                    }
+                    report(error, message)
+                })
+            self.dfuPacketCharacteristic?.sendFirmwareSize_v1(size)
         }
     }
     
@@ -352,7 +363,8 @@ import CoreBluetooth
      - parameter report:  A callback called when a response with an error status is received.
      */
     func sendInitPacket(_ data: Data,
-                        onSuccess success: @escaping Callback, onError report: @escaping ErrorCallback) {
+                        onSuccess success: @escaping Callback,
+                        onError report: @escaping ErrorCallback) {
         guard !aborted else {
             sendReset(onError: report)
             return
@@ -378,11 +390,16 @@ import CoreBluetooth
             // Therefore, there are 2 commands to the DFU Control Point required: one
             // before we start sending init packet, and another one the whole init packet
             // is sent. After sending the second packet a notification will be received.
-            dfuControlPointCharacteristic!.send(Request.initDfuParameters(req: InitDfuParametersRequest.receiveInitPacket), onSuccess: nil, onError: report)
-            dfuPacketCharacteristic!.sendInitPacket(data)
-            dfuControlPointCharacteristic!.send(Request.initDfuParameters(req: InitDfuParametersRequest.initPacketComplete), onSuccess: success,
-                onError: {
-                    error, message in
+            dfuControlPointCharacteristic?.send(
+                Request.initDfuParameters(req: InitDfuParametersRequest.receiveInitPacket),
+                onSuccess: nil,
+                onError: report
+            )
+            dfuPacketCharacteristic?.sendInitPacket(data)
+            dfuControlPointCharacteristic?.send(
+                Request.initDfuParameters(req: InitDfuParametersRequest.initPacketComplete),
+                onSuccess: success,
+                onError: { error, message in
                     if error == .remoteLegacyDFUOperationFailed {
                         // Init packet validation failed. The device type, revision, app
                         // version or SoftDevice version does not match values specified
@@ -400,9 +417,9 @@ import CoreBluetooth
             // After receiving this packet the DFU target was sending a notification with
             // status.
             if data.count == 2 {
-                dfuControlPointCharacteristic!.send(Request.initDfuParameters_v1,
+                dfuControlPointCharacteristic?.send(Request.initDfuParameters_v1,
                                                     onSuccess: success, onError: report)
-                dfuPacketCharacteristic!.sendInitPacket(data)
+                dfuPacketCharacteristic?.sendInitPacket(data)
             } else {
                 // After sending the Extended Init Packet, the DFU would fail on CRC
                 // validation eventually.
@@ -436,7 +453,7 @@ import CoreBluetooth
                                               onError report: @escaping ErrorCallback) {
         if !aborted {
             packetReceiptNotificationNumber = prnValue
-            dfuControlPointCharacteristic!.send(Request.packetReceiptNotificationRequest(number: prnValue),
+            dfuControlPointCharacteristic?.send(Request.packetReceiptNotificationRequest(number: prnValue),
                                                 onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
@@ -472,11 +489,13 @@ import CoreBluetooth
         // 2. Sends firmware to the DFU Packet characteristic. If number > 0 it will receive
         //    Packet Receit Notifications every number packets.
         // 3. Receives response notification and calls onSuccess or onError.
-        dfuControlPointCharacteristic!.send(Request.receiveFirmwareImage,
-            onSuccess: {
+        dfuControlPointCharacteristic?.send(Request.receiveFirmwareImage,
+            onSuccess: { [weak self] in
+                guard let self = self else { return }
                 // Register callbacks for Packet Receipt Notifications/Responses.
-                self.dfuControlPointCharacteristic!.waitUntilUploadComplete(
-                    onSuccess: {
+                self.dfuControlPointCharacteristic?.waitUntilUploadComplete(
+                    onSuccess: { [weak self] in
+                        guard let self = self else { return }
                         // Upload is completed, release the temporary parameters.
                         self.firmware = nil
                         self.report   = nil
@@ -484,8 +503,8 @@ import CoreBluetooth
                         self.progressQueue = nil
                         success()
                     },
-                    onPacketReceiptNofitication: {
-                        bytesReceived in
+                    onPacketReceiptNofitication: { [weak self] bytesReceived in
+                        guard let self = self else { return }
                         // This callback is called from SecureDFUControlPoint in 2 cases:
                         // when a PRN is received (bytesReceived contains number of bytes
                         // reported), or when the iOS reports the
@@ -499,14 +518,21 @@ import CoreBluetooth
                         
                         // Each time a PRN is received, send next bunch of packets
                         if !self.paused && !self.aborted {
-                            let bytesSent = self.dfuPacketCharacteristic!.bytesSent
+                            guard let dfuPacketCharacteristic = self.dfuPacketCharacteristic else {
+                                self.firmware = nil
+                                self.report   = nil
+                                self.progressDelegate = nil
+                                self.progressQueue = nil
+                                return
+                            }
+                            let bytesSent = dfuPacketCharacteristic.bytesSent
                             // Due to https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/issues/54
                             // only 16 least significant bits are verified.
                             if peripheralIsReadyToSendWriteWithoutRequest ||
                                (bytesSent & 0xFFFF) == (bytesReceived! & 0xFFFF) {
-                                self.dfuPacketCharacteristic!.sendNext(self.packetReceiptNotificationNumber,
-                                                                       packetsOf: firmware,
-                                                                       andReportProgressTo: progress, on: queue)
+                                dfuPacketCharacteristic.sendNext(self.packetReceiptNotificationNumber,
+                                                                 packetsOf: firmware,
+                                                                 andReportProgressTo: progress, on: queue)
                             } else {
                                 // Target device deported invalid number of bytes received
                                 report(.bytesLost, "\(bytesSent) bytes were sent while \(bytesReceived!) bytes were reported as received")
@@ -521,8 +547,8 @@ import CoreBluetooth
                             self.sendReset(onError: report)
                         }
                     },
-                    onError: {
-                        error, message in
+                    onError: { [weak self] error, message in
+                        guard let self = self else { return }
                         // Upload failed, release the temporary parameters.
                         self.firmware = nil
                         self.report   = nil
@@ -533,10 +559,11 @@ import CoreBluetooth
                 )
                 // ...and start sending firmware.
                 if !self.paused && !self.aborted {
-                    let start = {
+                    let start = { [weak self] in
+                        guard let self = self else { return }
                         self.logger.a("Uploading firmware...")
                         self.logger.v("Sending firmware to DFU Packet characteristic...")
-                        self.dfuPacketCharacteristic!.sendNext(self.packetReceiptNotificationNumber,
+                        self.dfuPacketCharacteristic?.sendNext(self.packetReceiptNotificationNumber,
                                                                packetsOf: firmware,
                                                                andReportProgressTo: progress, on: queue)
                     }
@@ -558,7 +585,8 @@ import CoreBluetooth
                     self.sendReset(onError: report)
                 }
             },
-            onError: report)
+            onError: report
+        )
     }
     
     /**
@@ -570,7 +598,7 @@ import CoreBluetooth
     func sendValidateFirmwareRequest(onSuccess success: @escaping Callback,
                                      onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.validateFirmware,
+            dfuControlPointCharacteristic?.send(Request.validateFirmware,
                                                 onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)
@@ -585,7 +613,7 @@ import CoreBluetooth
      */
     func sendActivateAndResetRequest(onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic!.send(Request.activateAndReset,
+            dfuControlPointCharacteristic?.send(Request.activateAndReset,
                                                 onSuccess: nil, onError: report)
         } else {
             sendReset(onError: report)
@@ -600,7 +628,7 @@ import CoreBluetooth
      - parameter report: A callback called when writing characteristic failed.
      */
     func sendReset(onError report: @escaping ErrorCallback) {
-        dfuControlPointCharacteristic!.send(Request.reset, onSuccess: nil, onError: report)
+        dfuControlPointCharacteristic?.send(Request.reset, onSuccess: nil, onError: report)
     }
     
     // MARK: - Private service API methods
@@ -614,13 +642,13 @@ import CoreBluetooth
     */
     private func readDfuVersion(onSuccess success: @escaping Callback,
                                 onError report: @escaping ErrorCallback) {
-        dfuVersionCharacteristic!.readVersion(
-            onSuccess: {
-                major, minor in
+        dfuVersionCharacteristic?.readVersion(
+            onSuccess: { [weak self] major, minor in
+                guard let self = self else { return }
                 self.version = (major, minor)
                 success()
             },
-            onError:report
+            onError: report
         )
     }
     
@@ -693,7 +721,12 @@ import CoreBluetooth
                 _report?(.readingVersionFailed, "DFU Version found, but does not have the Read property")
                 return
             }
-            readDfuVersion(onSuccess: _success!, onError: _report!)
+            guard let _success = _success,
+                  let _report = _report else {
+                // This should never happen.
+                return
+            }
+            readDfuVersion(onSuccess: _success, onError: _report)
         } else {
             // Else... proceed.
             version = nil

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -258,7 +258,7 @@ import CoreBluetooth
      - parameter success: A callback called when a response with status Success is received.
      - parameter report:  A callback called when a response with an error status is received.
      */
-    func sendDfuStart(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize,
+    func sendStartDfu(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize,
                       onSuccess success: @escaping Callback,
                       onError report: @escaping ErrorCallback) {
         guard !aborted else {
@@ -326,7 +326,7 @@ import CoreBluetooth
             return
         }
         
-        // See comment in sendDfuStart(withFirmwareType:andSize:onSuccess:onError) above
+        // See comment in sendStartDfu(withFirmwareType:andSize:onSuccess:onError) above
         logger.d("wait(1000)")
         queue.asyncAfter(deadline: .now() + .milliseconds(1000)) { [weak self] in
             guard let self = self else { return }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -100,18 +100,17 @@ internal struct ButtonlessDFUResponse {
     init?(_ data: Data) {
         // The correct response is always 3 bytes long: Response Op Code,
         // Request Op Code and Status.
-        guard data.count == 3 else { return nil }
-        let opCode        = ButtonlessDFUOpCode(rawValue: data[0])
-        let requestOpCode = ButtonlessDFUOpCode(rawValue: data[1])
-        let status        = ButtonlessDFUResultCode(rawValue: data[2])
-        
-        if opCode != .responseCode || requestOpCode == nil || status == nil {
+        guard data.count == 3,
+              let opCode = ButtonlessDFUOpCode(rawValue: data[0]),
+              let requestOpCode = ButtonlessDFUOpCode(rawValue: data[1]),
+              let status = ButtonlessDFUResultCode(rawValue: data[2]),
+              opCode == .responseCode else {
             return nil
         }
         
-        self.opCode        = opCode!
-        self.requestOpCode = requestOpCode!
-        self.status        = status!
+        self.opCode        = opCode
+        self.requestOpCode = requestOpCode
+        self.status        = status
     }
         
     var description: String {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -58,7 +58,8 @@ internal class SecureDFUPacket: DFUCharacteristic {
         self.logger = logger
         
         if #available(iOS 9.0, macOS 10.12, *) {
-            packetSize = UInt32(characteristic.service.peripheral.maximumWriteValueLength(for: .withoutResponse))
+            // Make the packet size the first word-aligned value that's less than the maximum.
+            packetSize = UInt32(characteristic.service.peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFFFFFC
             if packetSize > 20 {
                 // MTU is 3 bytes larger than payload
                 // (1 octet for Op-Code and 2 octets for Att Handle).

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -143,14 +143,15 @@ internal class SecureDFUPacket: DFUCharacteristic {
             totalBytesSentSinceProgessNotification = totalBytesSentWhenDfuStarted
             
             // Notify progress delegate that upload has started (0%).
-            queue.async(execute: {
+            queue.async {
                 progress?.dfuProgressDidChange(
                     for:   firmware.currentPart,
                     outOf: firmware.parts,
                     to:    0,
                     currentSpeedBytesPerSecond: 0.0,
-                    avgSpeedBytesPerSecond:     0.0)
-            })
+                    avgSpeedBytesPerSecond:     0.0
+                )
+            }
         }
         
         let originalPacketsToSendNow = packetsToSendNow
@@ -189,14 +190,15 @@ internal class SecureDFUPacket: DFUCharacteristic {
                 totalBytesSentSinceProgessNotification = totalBytesSent
                 
                 // Notify progress delegate of overall progress.
-                queue.async(execute: {
+                queue.async {
                     progress?.dfuProgressDidChange(
                         for:   firmware.currentPart,
                         outOf: firmware.parts,
                         to:    Int(currentProgress),
                         currentSpeedBytesPerSecond: currentSpeed,
-                        avgSpeedBytesPerSecond:     avgSpeed)
-                })
+                        avgSpeedBytesPerSecond:     avgSpeed
+                    )
+                }
                 progressReported = currentProgress
             }
             

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUServiceInitiator.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUServiceInitiator.swift
@@ -36,8 +36,7 @@ import CoreBluetooth
         // The firmware file must be specified before calling `start(...)`.
         guard let _ = file else {
             delegateQueue.async {
-                self.delegate?.dfuError(.fileNotSpecified, didOccurWithMessage:
-                    "Firmware not specified")
+                self.delegate?.dfuError(.fileNotSpecified, didOccurWithMessage: "Firmware not specified")
             }
             return nil
         }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -73,14 +73,14 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      Enables notifications on DFU Control Point characteristic.
      */
     func enableControlPoint() {
-        dfuService!.enableControlPoint(
+        dfuService?.enableControlPoint(
             onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
     
     override func isInApplicationMode(_ forceDfu: Bool) -> Bool {
-        let applicationMode = dfuService!.isInApplicationMode() ?? !forceDfu
+        let applicationMode = dfuService?.isInApplicationMode() ?? !forceDfu
         
         if applicationMode {
             logger.w("Application with buttonless update found")
@@ -97,15 +97,16 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      in `DFUServiceInitiator`.
      */
     func jumpToBootloader() {
-        newAddressExpected = dfuService!.newAddressExpected
+        guard let dfuService = dfuService else { return }
+        newAddressExpected = dfuService.newAddressExpected
 
         var name: String?
         if alternativeAdvertisingNameEnabled {
             if let userSuppliedName = alternativeAdvertisingName {
-                // Use the user supplied name
+                // Use the user supplied name.
                 name = userSuppliedName
             } else {
-                // Generate a random 8-character long name
+                // Generate a random 8-character long name.
                 name = String(format: "Dfu%05d", arc4random_uniform(100000))
             }
         }
@@ -113,7 +114,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         // See `peripheralDidDisconnect()` for details.
         possibleDisconnectionOnSettingAlternativeName = name != nil
         
-        dfuService!.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
+        dfuService.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
             onSuccess: {
                 self.jumpingToBootloader = true
                 // The device will now disconnect and
@@ -150,11 +151,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      object size.
      */
     func readDataObjectInfo() {
-        dfuService!.readDataObjectInfo(
-            onReponse: { (response) in
-                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response!.maxSize!,
-                                                               offset: response!.offset!,
-                                                               crc: response!.crc!)
+        dfuService?.readDataObjectInfo(
+            onReponse: { response in
+                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response.maxSize!,
+                                                               offset: response.offset!,
+                                                               crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -165,11 +166,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      object size.
      */
     func readCommandObjectInfo() {
-        dfuService!.readCommandObjectInfo(
-            onReponse: { (response) in
-                self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response!.maxSize!,
-                                                                  offset: response!.offset!,
-                                                                  crc: response!.crc!)
+        dfuService?.readCommandObjectInfo(
+            onReponse: { response in
+                self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response.maxSize!,
+                                                                  offset: response.offset!,
+                                                                  crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -181,7 +182,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter length: Exact size of the object.
      */
     func createDataObject(withLength length: UInt32) {
-        dfuService!.createDataObject(withLength: length,
+        dfuService?.createDataObject(withLength: length,
              onSuccess: { self.delegate?.peripheralDidCreateDataObject() },
              onError: defaultErrorCallback
         )
@@ -193,7 +194,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter length: Exact size of the object.
      */
     func createCommandObject(withLength length: UInt32) {
-        dfuService!.createCommandObject(withLength: length,
+        dfuService?.createCommandObject(withLength: length,
             onSuccess: { self.delegate?.peripheralDidCreateCommandObject() },
             onError: defaultErrorCallback
         )
@@ -210,7 +211,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func sendNextObject(from range: Range<Int>, of firmware: DFUFirmware,
                         andReportProgressTo progress: DFUProgressDelegate?,
                         on queue: DispatchQueue) {
-        dfuService!.sendNextObject(from: range, of: firmware,
+        dfuService?.sendNextObject(from: range, of: firmware,
             andReportProgressTo: progress, on: queue,
             onSuccess: { self.delegate?.peripheralDidReceiveObject() },
             onError: defaultErrorCallback
@@ -228,7 +229,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      - parameter newValue: Packet Receipt Notification value (0 to disable PRNs).
      */
     func setPRNValue(_ newValue: UInt16 = 0) {
-        dfuService!.setPacketReceiptNotificationValue(newValue,
+        dfuService?.setPacketReceiptNotificationValue(newValue,
             onSuccess: { self.delegate?.peripheralDidSetPRNValue() },
             onError: defaultErrorCallback
         )
@@ -245,7 +246,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         // It sends all bytes of init packet in up-to-20-byte packets.
         // The init packet may not be too long as sending > ~15 packets without
         // PRNs may lead to buffer overflow.
-        dfuService!.sendInitPacket(withdata: packetData)
+        dfuService?.sendInitPacket(withdata: packetData)
         self.delegate?.peripheralDidReceiveInitPacket()
     }
     
@@ -253,10 +254,10 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      Sends Calculate Checksum request.
      */
     func sendCalculateChecksumCommand() {
-        dfuService!.calculateChecksumCommand(
-            onSuccess: { (response) in
-                self.delegate?.peripheralDidSendChecksum(offset: response!.offset!,
-                                                         crc: response!.crc!)
+        dfuService?.calculateChecksumCommand(
+            onSuccess: { response in
+                self.delegate?.peripheralDidSendChecksum(offset: response.offset!,
+                                                         crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -276,7 +277,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func sendExecuteCommand(forCommandObject isCommandObject: Bool = false,
                             andActivateIf complete: Bool = false) {
         activating = complete
-        dfuService!.executeCommand(
+        dfuService?.executeCommand(
             onSuccess: { self.delegate?.peripheralDidExecuteObject() },
             onError: { (error, message) in
                 self.activating = false

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -65,7 +65,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     
     override init(_ initiator: DFUServiceInitiator, _ logger: LoggerHelper) {
         self.alternativeAdvertisingNameEnabled = initiator.alternativeAdvertisingNameEnabled
-        self.alternativeAdvertisingName = initiator.alternativeAdvertisingName
+        self.alternativeAdvertisingName = initiator.alternativeAdvertisingName.map { String($0.prefix(20)) }
         super.init(initiator, logger)
     }
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -120,7 +120,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                 // The device will now disconnect and
                 // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             },
-            onError: { (error, message) in
+            onError: { error, message in
                 self.jumpingToBootloader = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }
@@ -279,7 +279,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         activating = complete
         dfuService?.executeCommand(
             onSuccess: { self.delegate?.peripheralDidExecuteObject() },
-            onError: { (error, message) in
+            onError: { error, message in
                 self.activating = false
                 
                 // In SDK 15.2 (and perhaps 15.x), the DFU target may reoprt only full pages

--- a/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
+++ b/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
@@ -65,7 +65,7 @@ import Foundation
 /**
  *  The Logger delegate.
  */
-@objc public protocol LoggerDelegate : class {
+@objc public protocol LoggerDelegate: AnyObject {
     
     /**
      This method is called whenever a new log entry is to be saved. The logger


### PR DESCRIPTION
This version introduces the following features:
- Guarantee word-aligned writes to the packet characteristic (#366),
- Extended DFU Connection Timeout from 3 to 15 seconds (#411),
- Fixed 'deprecated class keyword for protocol objects' (#410),
- Migration to Xcode 12.5 and Swift 5.4,
- Support for Apple watchOS and tvOS on CocoaPods (#412),
- Unwrapping optionals fixed (#413),
- Truncating too long advertising names (#415)

Above that, Readme has been updated with the following changes:
- Add links to Xamarin binding libraries (#389 and #401),
- Add syntax highlighting to readme (#402),