### PR TITLE
Fix for unnecessary log message

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -117,6 +117,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         dfuService.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
             onSuccess: {
                 self.jumpingToBootloader = true
+                self.possibleDisconnectionOnSettingAlternativeName = false
                 // The device will now disconnect and
                 // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             },
@@ -142,6 +143,13 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         if possibleDisconnectionOnSettingAlternativeName {
             logger.e("Buttonless service not configured, see: https://devzone.nordicsemi.com/f/nordic-q-a/59881/advertising-rename-feature-not-working/243566#243566. To workaround, disable alternative advertising name.")
             possibleDisconnectionOnSettingAlternativeName = false
+            
+            // We could set the flag below to allow jumping to the bootloader mode
+            // without using alternative advertising name, but it's better to fail
+            // and make sure the user knows about the issue. It can be workarond
+            // by disabling alternative name in DFUServiceInitiator.
+            
+            // jumpingToBootloader = true
         }
         super.peripheralDidDisconnect()
     }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -123,6 +123,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             },
             onError: { error, message in
                 self.jumpingToBootloader = false
+                self.possibleDisconnectionOnSettingAlternativeName = false
                 self.delegate?.error(error, didOccurWithMessage: message)
             }
         )


### PR DESCRIPTION
This PR fixes #418.

The log message will only be shown when the device disconnects after sending alternative advertising name.