### PR TITLE
Fix for Xcode 13 Builds but retaining Xcode 12 and older compatibility

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -221,7 +221,11 @@ internal struct PacketReceiptNotification {
         self.report  = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -247,7 +251,11 @@ internal struct PacketReceiptNotification {
         self.resetSent = false
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -295,7 +303,11 @@ internal struct PacketReceiptNotification {
         self.uploadStartTime = CFAbsoluteTimeGetCurrent()
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -222,7 +222,7 @@ internal struct PacketReceiptNotification {
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -252,7 +252,7 @@ internal struct PacketReceiptNotification {
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -304,7 +304,7 @@ internal struct PacketReceiptNotification {
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
@@ -68,7 +68,7 @@ internal class DFUPacket: DFUCharacteristic {
     func sendFirmwareSize(_ size: DFUFirmwareSize) {
         // Get the peripheral object
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -94,7 +94,7 @@ internal class DFUPacket: DFUCharacteristic {
     func sendFirmwareSize_v1(_ size: DFUFirmwareSize) {
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -116,7 +116,7 @@ internal class DFUPacket: DFUCharacteristic {
     func sendInitPacket(_ data: Data) {
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -156,7 +156,7 @@ internal class DFUPacket: DFUCharacteristic {
                   andReportProgressTo progress: DFUProgressDelegate?, on queue: DispatchQueue) {
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUPacket.swift
@@ -67,7 +67,11 @@ internal class DFUPacket: DFUCharacteristic {
      */
     func sendFirmwareSize(_ size: DFUFirmwareSize) {
         // Get the peripheral object
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         let data = Data()
             + size.softdevice.littleEndian
@@ -89,7 +93,11 @@ internal class DFUPacket: DFUCharacteristic {
      */
     func sendFirmwareSize_v1(_ size: DFUFirmwareSize) {
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         let data = Data() + size.application.littleEndian
         
@@ -107,7 +115,11 @@ internal class DFUPacket: DFUCharacteristic {
      */
     func sendInitPacket(_ data: Data) {
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Data may be sent in up-to-20-bytes packets.
         var offset: UInt32 = 0
@@ -143,7 +155,11 @@ internal class DFUPacket: DFUCharacteristic {
     func sendNext(_ prnValue: UInt16, packetsOf firmware: DFUFirmware,
                   andReportProgressTo progress: DFUProgressDelegate?, on queue: DispatchQueue) {
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Some super complicated computations...
         let bytesTotal   = UInt32(firmware.data.count)

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -67,7 +67,7 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUVersion.swift
@@ -66,7 +66,11 @@ internal typealias VersionCallback = (_ major: UInt8, _ minor: UInt8) -> Void
         self.report = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -155,7 +155,11 @@ import CoreBluetooth
         self.report  = report
         
         // Get the peripheral object
+        #if swift(>=5.5)
+        guard let peripheral = service.peripheral else { return }
+        #else
         let peripheral = service.peripheral
+        #endif
         
         // Set the peripheral delegate to self
         peripheral.delegate = self
@@ -194,7 +198,12 @@ import CoreBluetooth
         // - we must be in the DFU mode already (otherwise the device would be useless...).
         // Note: On iOS the Generic Access and Generic Attribute services (nor HID Service)
         //       are not returned during service discovery.
-        let services = service.peripheral.services
+        #if swift(>=5.5)
+        guard let peripheral = service.peripheral else { return false }
+        #else
+        let peripheral = service.peripheral
+        #endif
+        let services = peripheral.services
         if services?.count == 1 {
             return false
         }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -179,7 +179,7 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -212,7 +212,7 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -178,7 +178,11 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         self.report  = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -207,7 +211,11 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         self.report  = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -352,7 +352,11 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         self.report   = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -380,7 +384,11 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         self.report   = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -409,7 +417,11 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         self.report   = report
         
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self
@@ -439,7 +451,11 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         self.report  = report
 
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Set the peripheral delegate to self.
         peripheral.delegate = self

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -353,7 +353,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -385,7 +385,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -418,7 +418,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -452,7 +452,7 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
 
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -59,7 +59,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
         
         if #available(iOS 9.0, macOS 10.12, *) {
             #if swift(>=5.5)
-            guard let service = characteristic.service, let peripheral = service.peripheral else {
+            guard let peripheral = characteristic.service?.peripheral else {
                 packetSize = 20 // Default MTU is 23.
                 return
             }
@@ -88,7 +88,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
     func sendInitPacket(_ data: Data) {
         // Get the peripheral object.
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif
@@ -127,7 +127,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
                   andReportProgressTo progress: DFUProgressDelegate?, on queue: DispatchQueue,
                   andCompletionTo complete: @escaping Callback) {
         #if swift(>=5.5)
-        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        guard let peripheral = characteristic.service?.peripheral else { return }
         #else
         let peripheral = characteristic.service.peripheral
         #endif

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -58,8 +58,16 @@ internal class SecureDFUPacket: DFUCharacteristic {
         self.logger = logger
         
         if #available(iOS 9.0, macOS 10.12, *) {
+            #if swift(>=5.5)
+            guard let service = characteristic.service, let peripheral = service.peripheral else {
+                packetSize = 20 // Default MTU is 23.
+                return
+            }
+            #else
+            let peripheral = characteristic.service.peripheral
+            #endif
             // Make the packet size the first word-aligned value that's less than the maximum.
-            packetSize = UInt32(characteristic.service.peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFFFFFC
+            packetSize = UInt32(peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFFFFFC
             if packetSize > 20 {
                 // MTU is 3 bytes larger than payload
                 // (1 octet for Op-Code and 2 octets for Att Handle).
@@ -79,7 +87,11 @@ internal class SecureDFUPacket: DFUCharacteristic {
      */
     func sendInitPacket(_ data: Data) {
         // Get the peripheral object.
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
         let peripheral = characteristic.service.peripheral
+        #endif
         
         // Data may be sent in up-to-20-bytes packets.
         var offset: UInt32 = 0
@@ -114,7 +126,11 @@ internal class SecureDFUPacket: DFUCharacteristic {
     func sendNext(_ prnValue: UInt16, packetsFrom range: Range<Int>, of firmware: DFUFirmware,
                   andReportProgressTo progress: DFUProgressDelegate?, on queue: DispatchQueue,
                   andCompletionTo complete: @escaping Callback) {
-        let peripheral          = characteristic.service.peripheral
+        #if swift(>=5.5)
+        guard let service = characteristic.service, let peripheral = service.peripheral else { return }
+        #else
+        let peripheral = characteristic.service.peripheral
+        #endif
         let objectData          = firmware.data.subdata(in: range)
         let objectSizeInBytes   = UInt32(objectData.count)
         let objectSizeInPackets = (objectSizeInBytes + packetSize - 1) / packetSize

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -145,7 +145,11 @@ import CoreBluetooth
         self.report  = report
         
         // Get the peripheral object
+        #if swift(>=5.5)
+        guard let peripheral = service.peripheral else { return }
+        #else
         let peripheral = service.peripheral
+        #endif
         
         // Set the peripheral delegate to self
         peripheral.delegate = self


### PR DESCRIPTION
In Swift 5.5 Apple changed CBCharacteristic's CBService from being unowned to weak, which breaks the existing code under Xcode 13 whilst at the same time, making said fixes break Xcode 12 due to the change being implemented via Swift versioning. I think this fix should work for both Xcode 13 users downgrading their installed Swift to 5.4 or older as well as the opposite, Xcode 12 users who upgrade their internal Swift version to 5.5 and newer.