### PR TITLE
Fix for Crash due to Swift runtime lowerBound <= upperBound check

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -430,7 +430,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         }
         let initPacketLength = UInt32(initPacket.count)
         guard offset < initPacketLength - offset else {
-            logger.e("offset \(offset) is larger or equal than initPacketLength - offset \(initPacketLength - offset).")
+            logger.e("Offset \(offset) is larger or equal than initPacketLength - offset \(initPacketLength - offset).")
             return
         }
         let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength - offset))

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -424,8 +424,16 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
                          This allows resuming uploading the Init Packet.
      */
     private func sendInitPacket(fromOffset offset: UInt32) {
-        let initPacketLength = UInt32(firmware.initPacket!.count)
-        let data = firmware.initPacket!.subdata(in: Int(offset) ..< Int(initPacketLength - offset))
+        guard let initPacket = firmware.initPacket else {
+            logger.e("Firmware initPacket is nil.")
+            return
+        }
+        let initPacketLength = UInt32(initPacket.count)
+        guard offset < initPacketLength - offset else {
+            logger.d("offset \(offset) is larger or equal than initPacketLength - offset \(initPacketLength - offset). No more Init Packet Data to send.")
+            return
+        }
+        let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength - offset))
         
         // Send following bytes of init packet (offset may be 0).
         peripheral.sendInitPacket(data) // -> peripheralDidReceiveInitPacket() will be called.

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -430,7 +430,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         }
         let initPacketLength = UInt32(initPacket.count)
         guard offset < initPacketLength - offset else {
-            logger.d("offset \(offset) is larger or equal than initPacketLength - offset \(initPacketLength - offset). No more Init Packet Data to send.")
+            logger.e("offset \(offset) is larger or equal than initPacketLength - offset \(initPacketLength - offset).")
             return
         }
         let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength - offset))


### PR DESCRIPTION
In SecureDFUExecutor's sendInitPacket(fromOffset:) the range might cause a crash if offset is larger or equal than initPacketLength - offset. I think this might happen when there's no Data to send, maybe because we sent it all?
Crash found through nRF Connect's logs.