### PR TITLE
Fix for Crash in SecureDFUExecutor's createDataObject() due to rangeIdx parameter being out of bounds

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -110,6 +110,10 @@ import Foundation
     /// Service has done 3 attempts to send the data.
     case crcError                             = 309
     
+    /// Raised when a programming invariant, such as a bounds check for an array,
+    /// has not been met.
+    case programmingError                     = 400
+    
     /// Returns whether the error has been returned by the remote device or
     /// occurred locally.
     var isRemote: Bool {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -435,10 +435,20 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
      Creates the new data object with length equal to the length of the range with given index.
      The ranges were calculated using `calculateFirmwareRanges()`.
      
+     - Requires: `firmwareRanges` must not be `nil` and `rangeIdx` parameter must be within bounds. Otherwise, `peripheral.defaultErrorCallback` will be called instead.
      - parameter rangeIdx: Index of a range of the firmware.
      */
     private func createDataObject(_ rangeIdx: Int) {
-        let currentRange = firmwareRanges![rangeIdx]
+        guard let firmwareRanges = firmwareRanges, 0..<firmwareRanges.count ~= rangeIdx else {
+            if let ranges = firmwareRanges {
+                peripheral.defaultErrorCallback(.programmingError, "Variable @rangeIdx \(rangeIdx) in \(#function) does not fit in range 0..<\(ranges.count)")
+            } else {
+                peripheral.defaultErrorCallback(.fileNotSpecified, "Variable @firmwareRanges in \(#function) is nil.")
+            }
+            return
+        }
+        
+        let currentRange = firmwareRanges[rangeIdx]
         peripheral.createDataObject(withLength: UInt32(currentRange.upperBound - currentRange.lowerBound))
         // -> peripheralDidCreateDataObject() will be called.
     }


### PR DESCRIPTION
Coming up with a fix for this was not easy. I think this is a reasonable compromise that doesn't break the project's structure, but I'm open to any suggestions.