### PR TITLE
Accepting garbage in notifications following valid data

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -142,7 +142,7 @@ internal struct Response {
     let status        : DFUResultCode
     
     init?(_ data: Data) {
-        guard data.count == 3,
+        guard data.count >= 3,
               let opCode = DFUOpCode(rawValue: data[0]),
               let requestOpCode = DFUOpCode(rawValue: data[1]),
               let status = DFUResultCode(rawValue: data[2]),
@@ -165,7 +165,7 @@ internal struct PacketReceiptNotification {
     let bytesReceived : UInt32
     
     init?(_ data: Data) {
-        guard data.count == 5,
+        guard data.count >= 5,
               let opCode = DFUOpCode(rawValue: data[0]),
               opCode == .packetReceiptNotification else {
             return nil

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -100,7 +100,7 @@ internal struct ButtonlessDFUResponse {
     init?(_ data: Data) {
         // The correct response is always 3 bytes long: Response Op Code,
         // Request Op Code and Status.
-        guard data.count == 3,
+        guard data.count >= 3,
               let opCode = ButtonlessDFUOpCode(rawValue: data[0]),
               let requestOpCode = ButtonlessDFUOpCode(rawValue: data[1]),
               let status = ButtonlessDFUResultCode(rawValue: data[2]),

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -204,7 +204,7 @@ internal struct SecureDFUResponse {
             case .readObjectInfo:
                 // The correct reponse for Read Object Info has additional 12 bytes:
                 // Max Object Size, Offset and CRC.
-                guard data.count == 15 else { return nil }
+                guard data.count >= 15 else { return nil }
                 let maxSize : UInt32 = data.asValue(offset: 3)
                 let offset  : UInt32 = data.asValue(offset: 7)
                 let crc     : UInt32 = data.asValue(offset: 11)
@@ -216,7 +216,7 @@ internal struct SecureDFUResponse {
             case .calculateChecksum:
                 // The correct reponse for Calculate Checksum has additional 8 bytes:
                 // Offset and CRC.
-                guard data.count == 11 else { return nil }
+                guard data.count >= 11 else { return nil }
                 let offset : UInt32 = data.asValue(offset: 3)
                 let crc    : UInt32 = data.asValue(offset: 7)
                 
@@ -234,7 +234,7 @@ internal struct SecureDFUResponse {
             // If extended error was received, parse the extended error code
             // The correct response for Read Error request has 4 bytes.
             // The 4th byte is the extended error code.
-            guard data.count == 4,
+            guard data.count >= 4,
                   let error = SecureDFUExtendedErrorCode(rawValue: data[3]) else {
                 return nil
             }
@@ -290,7 +290,7 @@ internal struct SecureDFUPacketReceiptNotification {
     let crc           : UInt32
 
     init?(_ data: Data) {
-        guard data.count == 11,
+        guard data.count >= 11,
               let opCode = SecureDFUOpCode(rawValue: data[0]),
               let requestOpCode = SecureDFUOpCode(rawValue: data[1]),
               let resultCode = SecureDFUResultCode(rawValue: data[2]),


### PR DESCRIPTION
This PR changes the way in which the iOS version of DFU library is handling too long notifications. Android version is just reading required bytes and ignoring any bytes following valid data. Until now, iOS version was strict and was terminating DFU when a notification was too long.
This PR should have no affect on standard bootloader implementation, but can help e.g. in #436. The root cause of this issue is still on the device side, but at least the iOS and Android library will behave in the same way.