### PR TITLE
Use connectionTimeout when reconnecting in DFU mode

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -616,7 +616,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
         if shouldReconnect {
             shouldReconnect = false
             // We need to reconnect to the device.
-            connect(withTimeout: 5.0)
+            connect(withTimeout: connectionTimeout)
         } else if jumpingToBootloader {
             jumpingToBootloader = false
             if newAddressExpected {
@@ -634,7 +634,7 @@ internal class BaseCommonDFUPeripheral<TD : DFUPeripheralDelegate, TS : DFUServi
                 }
             } else {
                 // Connect again, hoping for DFU mode this time.
-                connect(withTimeout: 5.0)
+                connect(withTimeout: connectionTimeout)
             }
         } else if activating {
             activating = false


### PR DESCRIPTION
When reconnecting to the peripheral after switching to DFU mode, a 5 seconds (hardcoded) timeout is used. With our devices this value seems to be too small and the update always fails because of connection timeout.

This PR addresses this issue by using the same `connectionTimeout` that is set when initially connecting to the peripheral.