### PR TITLE
Proposed fix for crash in calculateFirmwareRanges() due to division by zero

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -164,7 +164,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             onReponse: { response in
                 guard let maxSize = response.maxSize, maxSize > 0 else {
                     self.defaultErrorCallback(DFUError.unsupportedResponse,
-                                              "Received Maximum Response Size smaller than 1 byte.")
+                                              "Received invalid maxSize (nil or smaller than 1).")
                     return
                 }
                 self.delegate?.peripheralDidSendDataObjectInfo(maxLen: maxSize,

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -162,7 +162,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func readDataObjectInfo() {
         dfuService?.readDataObjectInfo(
             onReponse: { response in
-                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response.maxSize!,
+                guard let maxSize = response.maxSize, maxSize > 0 else {
+                    self.defaultErrorCallback(DFUError.unsupportedResponse,
+                                              "Received Maximum Response Size smaller than 1 byte.")
+                    return
+                }
+                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: maxSize,
                                                                offset: response.offset!,
                                                                crc: response.crc!)
             },


### PR DESCRIPTION
If the maxSize UInt32 is zero, the internal division inside calculateFirmwareRanges() will crash both the framework and the caller app.