### PR TITLE
Fix: Missing error codes added

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -30,6 +30,18 @@
 
 import Foundation
 
+internal enum DFURemoteError : Int {
+    case legacy                      = 0
+    case secure                      = 10
+    case secureExtended              = 20
+    case buttonless                  = 90
+    case experimentalButtonless      = 9000
+    
+    func with(code: UInt8) -> DFUError {
+        return DFUError(rawValue: Int(code) + rawValue)!
+    }
+}
+
 @objc public enum DFUError : Int {
     // Legacy DFU errors.
     case remoteLegacyDFUSuccess               = 1

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -52,6 +52,7 @@ import Foundation
     
     // This error will no longer be reported.
     case remoteSecureDFUExtendedError         = 21 // 10 + 11
+    
     // Instead, one of the extended errors below will used.
     case remoteExtendedErrorWrongCommandFormat   = 22 // 20 + 0x02
     case remoteExtendedErrorUnknownCommand       = 23 // 20 + 0x03
@@ -74,9 +75,12 @@ import Foundation
     
     // Buttonless DFU errors (received value + 90 as they overlap legacy
     // and secure DFU errors).
-    case remoteButtonlessDFUSuccess            = 91 // 90 + 1
-    case remoteButtonlessDFUOpCodeNotSupported = 92 // 90 + 2
-    case remoteButtonlessDFUOperationFailed    = 94 // 90 + 4
+    case remoteButtonlessDFUSuccess                     = 91 // 90 + 1
+    case remoteButtonlessDFUOpCodeNotSupported          = 92 // 90 + 2
+    case remoteButtonlessDFUOperationFailed             = 94 // 90 + 4
+    case remoteButtonlessDFUInvalidAdvertisementName    = 95 // 90 + 5
+    case remoteButtonlessDFUBusy                        = 96 // 90 + 6
+    case remoteButtonlessDFUNotBonded                   = 97 // 90 + 7
     
     /// Providing the DFUFirmware is required.
     case fileNotSpecified                     = 101

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -120,6 +120,14 @@ internal enum DFUResultCode : UInt8 {
     case crcError             = 5
     case operationFailed      = 6
     
+    var code: UInt8 {
+        return rawValue
+    }
+    
+    var error: DFUError {
+        return DFURemoteError.legacy.with(code: code)
+    }
+    
     var description: String {
         switch self {
         case .success:              return "Success"
@@ -129,10 +137,6 @@ internal enum DFUResultCode : UInt8 {
         case .crcError:             return "CRC Error"
         case .operationFailed:      return "Operation failed"
         }
-    }
-    
-    var code: UInt8 {
-        return rawValue
     }
 }
 
@@ -455,7 +459,7 @@ internal struct PacketReceiptNotification {
                 success?()
             } else {
                 logger.e("Error \(response.status.code): \(response.status.description)")
-                report?(DFUError(rawValue: Int(response.status.rawValue))!, response.status.description)
+                report?(response.status.error, response.status.description)
             }
         } else {
             logger.e("Unknown response received: 0x\(characteristicValue.hexString)")

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -147,6 +147,14 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
     }
     
     /**
+     Returns whether the characteristic is an instance of Experimental Buttonless
+     DFU Service from SDK 12.
+     */
+    internal var isExperimental: Bool {
+        return characteristic.uuid.isEqual(uuidHelper.buttonlessExperimentalCharacteristic)
+    }
+    
+    /**
      Returns `true` for a buttonless DFU characteristic that may support setting
      bootloader's name. This feature has been added in SDK 14.0 to Buttonless
      service without bond sharing (the one with bond sharing does not change 
@@ -310,7 +318,7 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         
         guard dfuResponse.status == .success else {
             logger.e("Error \(dfuResponse.status.code): \(dfuResponse.status.description)")
-            let type = characteristic.uuid.isEqual(uuidHelper.buttonlessExperimentalCharacteristic) ?
+            let type = isExperimental ?
                 DFURemoteError.experimentalButtonless :
                 DFURemoteError.buttonless
             report?(dfuResponse.status.error(ofType: type), dfuResponse.status.description)

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -62,6 +62,10 @@ internal enum SecureDFUExtendedErrorCode : UInt8 {
         return rawValue
     }
     
+    var error: DFUError {
+        return DFURemoteError.secureExtended.with(code: code)
+    }
+    
     var description: String {
         switch self {
         case .noError:              return "No error"
@@ -155,6 +159,14 @@ internal enum SecureDFUResultCode : UInt8 {
     case operationFailed       = 0x0A
     case extendedError         = 0x0B
     
+    var code: UInt8 {
+        return rawValue
+    }
+    
+    var error: DFUError {
+        return DFURemoteError.secure.with(code: code)
+    }
+    
     var description: String {
         switch self {
             case .invalidCode:           return "Invalid code"
@@ -169,10 +181,6 @@ internal enum SecureDFUResultCode : UInt8 {
             case .operationFailed:       return "Operation failed"
             case .extendedError:         return "Extended error"
         }
-    }
-    
-    var code: UInt8 {
-        return rawValue
     }
 }
 
@@ -576,12 +584,10 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         case .extendedError:
             // An extended error was received.
             logger.e("Error \(dfuResponse.error!.code): \(dfuResponse.error!.description)")
-            // The returned errod code is incremented by 20 to match Secure DFU remote codes.
-            report?(DFUError(rawValue: Int(dfuResponse.error!.code) + 20)!, dfuResponse.error!.description)
+            report?(dfuResponse.error!.error, dfuResponse.error!.description)
         default:
             logger.e("Error \(dfuResponse.status.code): \(dfuResponse.status.description)")
-            // The returned errod code is incremented by 10 to match Secure DFU remote codes.
-            report?(DFUError(rawValue: Int(dfuResponse.status.code) + 10)!, dfuResponse.status.description)
+            report?(dfuResponse.status.error, dfuResponse.status.description)
         }
     }
     


### PR DESCRIPTION
This PR fixes a crash when one of 3 missing status codes was received. The `DFUError` enum failed to be instantiated here:
https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/d754328a4d13d28962f4db0f724ea2591be48478/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift#L313
This PR adds those cases to the enum.