### PR TITLE
New Secure DFU op codes, including Abort

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -200,6 +200,14 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         delegate = nil
     }
     
+    func resetDevice() {
+        if let peripheral = peripheral, peripheral.state != .disconnected {
+            disconnect()
+        } else {
+            peripheralDidDisconnect()
+        }
+    }
+    
     // MARK: - DFU Controller API
     
     func pause() -> Bool {
@@ -403,17 +411,6 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         // Notify the delegate about the disconnection.
         // Most probably an error occurred and will be reported to the user.
         delegate?.peripheralDidDisconnect()
-    }
-    
-    /**
-     This method should reset the device, preferably switching it to application mode.
-     */
-    func resetDevice() {
-        if let peripheral = peripheral, peripheral.state != .disconnected {
-            disconnect()
-        } else {
-            peripheralDidDisconnect()
-        }
     }
     
     // MARK: - Private methods

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -48,7 +48,6 @@ import CoreBluetooth
     private var dfuControlPointCharacteristic : DFUControlPoint?
     private var dfuVersionCharacteristic      : DFUVersion?
     
-
     /// This method returns true if DFU Control Point characteristc has been discovered.
     /// A device without this characteristic is not supported and even can't be resetted
     /// by sending a Reset command.

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -329,4 +329,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             }
         )
     }
+    
+    override func resetDevice() {
+        guard let dfuService = dfuService, dfuService.supportsReset() else {
+            super.resetDevice()
+            return
+        }
+        dfuService.sendReset(onError: defaultErrorCallback)
+    }
 }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -47,6 +47,17 @@ import CoreBluetooth
     private let service                       : CBService
     private var dfuPacketCharacteristic       : SecureDFUPacket?
     private var dfuControlPointCharacteristic : SecureDFUControlPoint?
+    
+    /// This method returns true if DFU Control Point characteristc has been discovered.
+    /// A device without this characteristic is not supported and even can't be resetted
+    /// by sending a Reset command.
+    internal func supportsReset() -> Bool {
+        // The Abort (0x0C) command has been added to DFU bootloader in SDK 15.
+        // https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/lib_dfu_transport.html?cp=8_5_3_3_5_2
+        // For earlier SDKs there is no way to reset the bootloader other than
+        // disconnecting and waiting for it to time out after few minutes.
+        return dfuControlPointCharacteristic != nil
+    }
 
     private var paused  = false
     private var aborted = false
@@ -55,7 +66,7 @@ import CoreBluetooth
     private var success          : Callback?
     /// A temporary callback used to report an operation error.
     private var report           : ErrorCallback?
-    /// A temporaty callback used to report progress status.
+    /// A temporary callback used to report progress status.
     private var progressDelegate : DFUProgressDelegate?
     private var progressQueue    : DispatchQueue?
     
@@ -323,10 +334,19 @@ import CoreBluetooth
      
      - parameter report: A callback called when writing characteristic failed.
      */
-    private func sendReset(onError report: @escaping ErrorCallback) {
+    func sendReset(onError report: @escaping ErrorCallback) {
         aborted = true
-        // There is no command to reset a Secure DFU device. We can just disconnect.
-        targetPeripheral?.disconnect()
+        // Upon sending the Abort request the device will immediately reboot in application
+        // mode. There will be no notification with status success returned.
+        dfuControlPointCharacteristic?.send(.abort,
+            onSuccess: nil, // Device will disconnected immediately.
+            onError: { [weak self] _, _ in
+                // Seems like the Abort request is not supported (indicating SDK 12-14).
+                // We can just disconnect. The bootloader should reset to app mode after
+                // a timeout.
+                self?.targetPeripheral?.disconnect()
+            }
+        )
     }
     
     //MARK: - Packet commands


### PR DESCRIPTION
SDK 15 added new Op Codes to DFU bootloader ([before](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.2.0/lib_dfu_transport.html?cp=8_5_4_3_5_2), [after](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/lib_dfu_transport.html?cp=8_5_3_3_5_2)):

| Op Code | Name |
| --- | --- |
| 0x00 | Get Protocol Version |
| 0x07 | Get MTU |
| 0x08 | Write |
| 0x09 | Ping |
| 0x0A | Get HW Version |
| 0x0B | Get FW Version |
| 0x0C |Abort |

This PR adds them to supported commands, and adds support for Abort request. The other requests are not used and were added for completeness. 

Before this PR, Secure DFU was disconnecting in case of an error, leaving the bootloader in its state. The bootloader would eventually timeout, switching back to Application mode after few minutes. With the new Abort request, this is instantaneous. When using bootloader from SDK 12-14 the lib will try to send Abort request, which will be responded with Op Code Not Supported, after which the lib will revert to old behavior and disconnect.

The new behavior is automatic and does not require any changes in the app's code.