### PR TITLE
Version 4.11.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSDFULibrary (4.10.4):
+  - iOSDFULibrary (4.11.0):
     - ZIPFoundation (= 0.9.11)
   - ZIPFoundation (0.9.11)
 
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSDFULibrary: 5d41d0ac69418d63755195db5f46e99588ae7d48
+  iOSDFULibrary: ca2a4da1f1680fe4957b0a33ad605c9e10f7ae7c
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
 PODFILE CHECKSUM: 16697609d795697cac6384a823bc962ccbddb9d0
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/Example/Pods/Local Podspecs/iOSDFULibrary.podspec.json
+++ b/Example/Pods/Local Podspecs/iOSDFULibrary.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "iOSDFULibrary",
-  "version": "4.10.4",
-  "summary": "This repository contains a tested library for iOS 9+ devices to perform Device Firmware Update on the nRF5x devices",
+  "version": "4.11.0",
+  "summary": "This repository contains a library to perform Device Firmware Update on the nRF5x devices.",
   "description": "The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.",
   "homepage": "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library",
   "license": "BSD 3-Clause",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library.git",
-    "tag": "4.10.4"
+    "tag": "4.11.0"
   },
   "social_media_url": "https://twitter.com/nordictweets",
   "swift_versions": [
@@ -19,7 +19,8 @@
     "5.1",
     "5.2",
     "5.3",
-    "5.4"
+    "5.4",
+    "5.5"
   ],
   "platforms": {
     "ios": "9.0",
@@ -33,5 +34,5 @@
       "= 0.9.11"
     ]
   },
-  "swift_version": "5.4"
+  "swift_version": "5.5"
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSDFULibrary (4.10.4):
+  - iOSDFULibrary (4.11.0):
     - ZIPFoundation (= 0.9.11)
   - ZIPFoundation (0.9.11)
 
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSDFULibrary: 5d41d0ac69418d63755195db5f46e99588ae7d48
+  iOSDFULibrary: ca2a4da1f1680fe4957b0a33ad605c9e10f7ae7c
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
 PODFILE CHECKSUM: 16697609d795697cac6384a823bc962ccbddb9d0
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1002,7 +1002,7 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1100;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1250;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
@@ -1330,38 +1330,7 @@
 			};
 			name = Debug;
 		};
-		20D48A476333DC3994F22CBDECDA0E83 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A90170B238A8F30692726749801CA0A /* iOSDFULibrary-iOS.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS.modulemap";
-				PRODUCT_MODULE_NAME = iOSDFULibrary;
-				PRODUCT_NAME = iOSDFULibrary;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.4;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		29A07C034A4E644460E6D64F82CC9EDB /* Debug */ = {
+		2434CD48230FB2401C104B1CBC813C44 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07E3623AEDB4B5AFD35E16D05442F170 /* iOSDFULibrary-iOS.debug.xcconfig */;
 			buildSettings = {
@@ -1384,7 +1353,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.4;
+				SWIFT_VERSION = 5.5;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1617,9 +1586,9 @@
 			};
 			name = Debug;
 		};
-		79EACAB1D84E3247A4FE75A5E1F0AB45 /* Debug */ = {
+		662BA473114DE61CDEAED8A1503AD5FF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD4CD31BA2F18B60F27B1CB65C362BE0 /* iOSDFULibrary-macOS.debug.xcconfig */;
+			baseConfigurationReference = FA7938C19E625B145056CBFFBD5CECA5 /* iOSDFULibrary-macOS.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1642,11 +1611,11 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.4;
+				SWIFT_VERSION = 5.5;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
 		8FFC49A2EAC02042AF9C48F70834D814 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1680,32 +1649,32 @@
 			};
 			name = Debug;
 		};
-		AB98EBF77A78989B26A306580CA2D378 /* Release */ = {
+		9C288C60F1E383E1F92427D8C96CEA6A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FA7938C19E625B145056CBFFBD5CECA5 /* iOSDFULibrary-macOS.release.xcconfig */;
+			baseConfigurationReference = 6A90170B238A8F30692726749801CA0A /* iOSDFULibrary-iOS.release.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS.modulemap";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS.modulemap";
 				PRODUCT_MODULE_NAME = iOSDFULibrary;
 				PRODUCT_NAME = iOSDFULibrary;
-				SDKROOT = macosx;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.4;
+				SWIFT_VERSION = 5.5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1741,6 +1710,37 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		C0BF92D6AD3007FEE12ED42DE13EA22E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CD4CD31BA2F18B60F27B1CB65C362BE0 /* iOSDFULibrary-macOS.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MODULEMAP_FILE = "Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS.modulemap";
+				PRODUCT_MODULE_NAME = iOSDFULibrary;
+				PRODUCT_NAME = iOSDFULibrary;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.5;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		C86AFE4ECEEF82D540A27F1DFD7FB91E /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1875,8 +1875,8 @@
 		3CE6B3EE0B92EECD5CF1CFD891E7A485 /* Build configuration list for PBXNativeTarget "iOSDFULibrary-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				79EACAB1D84E3247A4FE75A5E1F0AB45 /* Debug */,
-				AB98EBF77A78989B26A306580CA2D378 /* Release */,
+				C0BF92D6AD3007FEE12ED42DE13EA22E /* Debug */,
+				662BA473114DE61CDEAED8A1503AD5FF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1929,8 +1929,8 @@
 		C91F17F18C6465D270B2E4BB6328F205 /* Build configuration list for PBXNativeTarget "iOSDFULibrary-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				29A07C034A4E644460E6D64F82CC9EDB /* Debug */,
-				20D48A476333DC3994F22CBDECDA0E83 /* Release */,
+				2434CD48230FB2401C104B1CBC813C44 /* Debug */,
+				9C288C60F1E383E1F92427D8C96CEA6A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist
+++ b/Example/Pods/Target Support Files/iOSDFULibrary-iOS/iOSDFULibrary-iOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.10.4</string>
+  <string>4.11.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist
+++ b/Example/Pods/Target Support Files/iOSDFULibrary-macOS/iOSDFULibrary-macOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.10.4</string>
+  <string>4.11.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library", 
-      .upToNextMajor(from: "<Desired Version, e.g. 4.10.4>")
+      .upToNextMajor(from: "<Desired Version, e.g. 4.11.0>")
     )
   ],
   targets: [.target(name: "<Your Target Name>", dependencies: ["NordicDFU"])]

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,13 @@
 ### Changelog
+- **4.11.0**
+   - Feature: Support for Abort op code added in Secure DFU (#447). 
+   - Improvement: More op codes added in Secure DFU in SDK 15 (#447).
+   - Improvement: Use connection timeout when reconnecting in DFU mode (#442).
+   - Bugfix: Handling missing error codes (#446).
+   - Bugfix: Handling invalid max object size (#443, #444).
+   - Other improvements (#445, #448).
+   - Read Object Info renamed to Select Object, like in DFU specification.
+   
 - **4.10.4**
    - Fix for compilation error in Xcode 13 related to change in iOS API (#433, #439).
    - Improvement: State validation (#434, #435, #437).

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
-  s.version          = "4.10.4"
-  s.summary          = "This repository contains a tested library for iOS 9+ devices to perform Device Firmware Update on the nRF5x devices"
+  s.version          = "4.11.0"
+  s.summary          = "This repository contains a library to perform Device Firmware Update on the nRF5x devices."
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.
                        DESC
@@ -11,7 +11,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
   s.authors          = { "Aleksander Nowakowski" => "aleksander.nowakowski@nordicsemi.no" }
   s.source           = { :git => "https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/nordictweets'
-  s.swift_versions   = ['4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
+  s.swift_versions   = ['4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
   
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.14'

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -30,6 +30,18 @@
 
 import Foundation
 
+internal enum DFURemoteError : Int {
+    case legacy                      = 0
+    case secure                      = 10
+    case secureExtended              = 20
+    case buttonless                  = 90
+    case experimentalButtonless      = 9000
+    
+    func with(code: UInt8) -> DFUError {
+        return DFUError(rawValue: Int(code) + rawValue)!
+    }
+}
+
 @objc public enum DFUError : Int {
     // Legacy DFU errors.
     case remoteLegacyDFUSuccess               = 1

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -38,6 +38,10 @@ internal enum DFURemoteError : Int {
     case experimentalButtonless      = 9000
     
     func with(code: UInt8) -> DFUError {
+        // The force-unwrap here is used, as the only available codes
+        // that this method is called with are hardcoded in the library
+        // (ButtonlessDFU, DFUControlPoint, SecureDFUControlPoint)
+        // and, with the optional offset, will match an existing DFUError.
         return DFUError(rawValue: Int(code) + rawValue)!
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUServiceDelegate.swift
@@ -52,6 +52,7 @@ import Foundation
     
     // This error will no longer be reported.
     case remoteSecureDFUExtendedError         = 21 // 10 + 11
+    
     // Instead, one of the extended errors below will used.
     case remoteExtendedErrorWrongCommandFormat   = 22 // 20 + 0x02
     case remoteExtendedErrorUnknownCommand       = 23 // 20 + 0x03
@@ -74,9 +75,12 @@ import Foundation
     
     // Buttonless DFU errors (received value + 90 as they overlap legacy
     // and secure DFU errors).
-    case remoteButtonlessDFUSuccess            = 91 // 90 + 1
-    case remoteButtonlessDFUOpCodeNotSupported = 92 // 90 + 2
-    case remoteButtonlessDFUOperationFailed    = 94 // 90 + 4
+    case remoteButtonlessDFUSuccess                     = 91 // 90 + 1
+    case remoteButtonlessDFUOpCodeNotSupported          = 92 // 90 + 2
+    case remoteButtonlessDFUOperationFailed             = 94 // 90 + 4
+    case remoteButtonlessDFUInvalidAdvertisementName    = 95 // 90 + 5
+    case remoteButtonlessDFUBusy                        = 96 // 90 + 6
+    case remoteButtonlessDFUNotBonded                   = 97 // 90 + 7
     
     /// Providing the DFUFirmware is required.
     case fileNotSpecified                     = 101

--- a/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
+++ b/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
@@ -56,7 +56,7 @@ import Foundation
 
 /// The DFUFirmware object wraps the firmware file.
 @objc public class DFUFirmware : NSObject, DFUStream {
-    internal let stream: DFUStream?
+    internal let stream: DFUStream
     
     /// The name of the firmware file.
     @objc public let fileName: String?
@@ -65,33 +65,31 @@ import Foundation
     
     /// Information whether the firmware was successfully initialized.
     @objc public var valid: Bool {
-        return stream != nil
+        // init(...) would return nil if the firmware was invalid.
+        return true
     }
     
     /// The size of each component of the firmware.
     @objc public var size: DFUFirmwareSize {
-        return stream!.size
+        return stream.size
     }
     
     /// Number of connectinos required to transfer the firmware.
     /// This does not include the connection needed to switch to the DFU mode.
     @objc public var parts: Int {
-        if stream == nil {
-            return 0
-        }
-        return stream!.parts
+        return stream.parts
     }
     
     internal var currentPartSize: DFUFirmwareSize {
-        return stream!.currentPartSize
+        return stream.currentPartSize
     }
     
     internal var currentPartType: UInt8 {
-        return stream!.currentPartType
+        return stream.currentPartType
     }
     
     internal var currentPart: Int {
-        return stream!.currentPart
+        return stream.currentPart
     }
     
     /**
@@ -128,8 +126,6 @@ import Foundation
         let ext = urlToZipFile.pathExtension
         if ext.caseInsensitiveCompare("zip") != .orderedSame {
             NSLog("\(fileName!) is not a ZIP file")
-            stream = nil
-            super.init()
             return nil
         }
         
@@ -137,8 +133,6 @@ import Foundation
             stream = try DFUStreamZip(urlToZipFile: urlToZipFile, type: type)
         } catch let error as NSError {
             NSLog("Error while creating ZIP stream: \(error.localizedDescription)")
-            stream = nil
-            super.init()
             return nil
         }
         super.init()
@@ -177,8 +171,6 @@ import Foundation
             stream = try DFUStreamZip(zipFile: zipFile, type: type)
         } catch let error as NSError {
             NSLog("Error while creating ZIP stream: \(error.localizedDescription)")
-            stream = nil
-            super.init()
             return nil
         }
         super.init()
@@ -205,8 +197,6 @@ import Foundation
         let hex = ext.caseInsensitiveCompare("hex") == .orderedSame
         guard bin || hex else {
             NSLog("\(fileName!) is not a BIN or HEX file")
-            stream = nil
-            super.init()
             return nil
         }
         
@@ -214,8 +204,6 @@ import Foundation
             let datExt = datUrl.pathExtension
             guard datExt.caseInsensitiveCompare("dat") == .orderedSame else {
                 NSLog("\(fileName!) is not a DAT file")
-                stream = nil
-                super.init()
                 return nil
             }
         }
@@ -275,18 +263,18 @@ import Foundation
     }
     
     internal var data: Data {
-        return stream!.data as Data
+        return stream.data as Data
     }
     
     internal var initPacket: Data? {
-        return stream!.initPacket as Data?
+        return stream.initPacket as Data?
     }
     
     internal func hasNextPart() -> Bool {
-        return stream!.hasNextPart()
+        return stream.hasNextPart()
     }
     
     internal func switchToNextPart() {
-        stream!.switchToNextPart()
+        stream.switchToNextPart()
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -200,6 +200,14 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         delegate = nil
     }
     
+    func resetDevice() {
+        if let peripheral = peripheral, peripheral.state != .disconnected {
+            disconnect()
+        } else {
+            peripheralDidDisconnect()
+        }
+    }
+    
     // MARK: - DFU Controller API
     
     func pause() -> Bool {
@@ -403,17 +411,6 @@ internal class BaseDFUPeripheral<TD : BasePeripheralDelegate> : NSObject, BaseDF
         // Notify the delegate about the disconnection.
         // Most probably an error occurred and will be reported to the user.
         delegate?.peripheralDidDisconnect()
-    }
-    
-    /**
-     This method should reset the device, preferably switching it to application mode.
-     */
-    func resetDevice() {
-        if let peripheral = peripheral, peripheral.state != .disconnected {
-            disconnect()
-        } else {
-            peripheralDidDisconnect()
-        }
     }
     
     // MARK: - Private methods

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -120,6 +120,14 @@ internal enum DFUResultCode : UInt8 {
     case crcError             = 5
     case operationFailed      = 6
     
+    var code: UInt8 {
+        return rawValue
+    }
+    
+    var error: DFUError {
+        return DFURemoteError.legacy.with(code: code)
+    }
+    
     var description: String {
         switch self {
         case .success:              return "Success"
@@ -129,10 +137,6 @@ internal enum DFUResultCode : UInt8 {
         case .crcError:             return "CRC Error"
         case .operationFailed:      return "Operation failed"
         }
-    }
-    
-    var code: UInt8 {
-        return rawValue
     }
 }
 
@@ -455,7 +459,7 @@ internal struct PacketReceiptNotification {
                 success?()
             } else {
                 logger.e("Error \(response.status.code): \(response.status.description)")
-                report?(DFUError(rawValue: Int(response.status.rawValue))!, response.status.description)
+                report?(response.status.error, response.status.description)
             }
         } else {
             logger.e("Unknown response received: 0x\(characteristicValue.hexString)")

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Characteristics/DFUControlPoint.swift
@@ -120,6 +120,9 @@ internal enum DFUResultCode : UInt8 {
     case crcError             = 5
     case operationFailed      = 6
     
+    // Note: When more result codes are added, the corresponding DFUError
+    //       case needs to be added. See `error` property below.
+    
     var code: UInt8 {
         return rawValue
     }
@@ -182,7 +185,7 @@ internal struct PacketReceiptNotification {
         // instad of 32-bit. However, the packet is still 5 bytes long and the two last
         // bytes are 0x00-00. This has to be taken under consideration when comparing
         // number of bytes sent and received as the latter counter may rewind if fw size
-        // is > 0xFFFF bytes (LegacyDFUService:L446).
+        // is > 0xFFFF bytes (LegacyDFUService:L543).
         self.bytesReceived = data.asValue(offset: 1)
     }
 }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Peripherals/LegacyDFUPeripheral.swift
@@ -60,7 +60,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func enableControlPoint() {
         dfuService?.enableControlPoint(
-            onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
@@ -88,9 +88,9 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.jumpToBootloaderMode(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { error, message in
-                self.jumpingToBootloader = false
-                self.delegate?.error(error, didOccurWithMessage: message)
+            onError: { [weak self] error, message in
+                self?.jumpingToBootloader = false
+                self?.delegate?.error(error, didOccurWithMessage: message)
             }
         )
     }
@@ -110,8 +110,9 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func sendStartDfu(withFirmwareType type: UInt8, andSize size: DFUFirmwareSize) {
         dfuService?.sendStartDfu(withFirmwareType: type, andSize: size,
-            onSuccess: { self.delegate?.peripheralDidStartDfu() },
-            onError: { error, message in
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidStartDfu() },
+            onError: { [weak self] error, message in
+                guard let self = self else { return }
                 if error == .remoteLegacyDFUNotSupported {
                     self.logger.w("DFU target does not support DFU v.2")
                     self.delegate?.peripheralDidFailToStartDfuWithType()
@@ -141,7 +142,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         slowDfuMode = true
         
         dfuService.sendStartDfu(withFirmwareSize: size,
-            onSuccess: { self.delegate?.peripheralDidStartDfu() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidStartDfu() },
             onError: defaultErrorCallback
         )
     }
@@ -154,7 +155,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func sendInitPacket(_ data: Data) {
         dfuService?.sendInitPacket(data,
-            onSuccess: { self.delegate?.peripheralDidReceiveInitPacket() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidReceiveInitPacket() },
             onError: defaultErrorCallback
         )
     }
@@ -181,11 +182,12 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
             prn = 1
         }
         dfuService?.sendPacketReceiptNotificationRequest(prn,
-            onSuccess: {
+            onSuccess: { [weak self] in
+                guard let self = self else { return }
                 // Now the service is ready to send the firmware.
                 self.dfuService?.sendFirmware(firmware, withDelay: self.slowDfuMode,
                     andReportProgressTo: progress, on: queue,
-                    onSuccess: { self.delegate?.peripheralDidReceiveFirmware() },
+                    onSuccess: { [weak self] in self?.delegate?.peripheralDidReceiveFirmware() },
                     onError: self.defaultErrorCallback
                 )
             },
@@ -199,7 +201,7 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
      */
     func validateFirmware() {
         dfuService?.sendValidateFirmwareRequest(
-            onSuccess: { self.delegate?.peripheralDidVerifyFirmware() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidVerifyFirmware() },
             onError: defaultErrorCallback
         )
     }
@@ -219,9 +221,9 @@ internal class LegacyDFUPeripheral : BaseCommonDFUPeripheral<LegacyDFUExecutor, 
         dfuService.sendActivateAndResetRequest(
             // On success, the device gets disconnected and
             // `centralManager(_:didDisconnectPeripheral:error)` will be called.
-            onError: { error, message in
-                self.activating = false
-                self.delegate?.error(error, didOccurWithMessage: message)
+            onError: { [weak self] error, message in
+                self?.activating = false
+                self?.delegate?.error(error, didOccurWithMessage: message)
             }
         )
     }

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -48,7 +48,6 @@ import CoreBluetooth
     private var dfuControlPointCharacteristic : DFUControlPoint?
     private var dfuVersionCharacteristic      : DFUVersion?
     
-
     /// This method returns true if DFU Control Point characteristc has been discovered.
     /// A device without this characteristic is not supported and even can't be resetted
     /// by sending a Reset command.

--- a/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift
@@ -64,7 +64,7 @@ import CoreBluetooth
     private var success: Callback?
     /// A temporary callback used to report an operation error.
     private var report:  ErrorCallback?
-    /// A temporaty callback used to report progress status.
+    /// A temporary callback used to report progress status.
     private var progressDelegate: DFUProgressDelegate?
     private var progressQueue: DispatchQueue?
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -147,6 +147,14 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
     }
     
     /**
+     Returns whether the characteristic is an instance of Experimental Buttonless
+     DFU Service from SDK 12.
+     */
+    internal var isExperimental: Bool {
+        return characteristic.uuid.isEqual(uuidHelper.buttonlessExperimentalCharacteristic)
+    }
+    
+    /**
      Returns `true` for a buttonless DFU characteristic that may support setting
      bootloader's name. This feature has been added in SDK 14.0 to Buttonless
      service without bond sharing (the one with bond sharing does not change 
@@ -310,7 +318,7 @@ internal class ButtonlessDFU : NSObject, CBPeripheralDelegate, DFUCharacteristic
         
         guard dfuResponse.status == .success else {
             logger.e("Error \(dfuResponse.status.code): \(dfuResponse.status.description)")
-            let type = characteristic.uuid.isEqual(uuidHelper.buttonlessExperimentalCharacteristic) ?
+            let type = isExperimental ?
                 DFURemoteError.experimentalButtonless :
                 DFURemoteError.buttonless
             report?(dfuResponse.status.error(ofType: type), dfuResponse.status.description)

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/ButtonlessDFU.swift
@@ -59,6 +59,9 @@ internal enum ButtonlessDFUResultCode : UInt8 {
     /// The request was rejected because no bond was created.
     case notBonded          = 0x07
     
+    // Note: When more result codes are added, the corresponding DFUError
+    //       case needs to be added. See `error(ofType:)` method below.
+    
     var code: UInt8 {
         return rawValue
     }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -62,6 +62,10 @@ internal enum SecureDFUExtendedErrorCode : UInt8 {
         return rawValue
     }
     
+    var error: DFUError {
+        return DFURemoteError.secureExtended.with(code: code)
+    }
+    
     var description: String {
         switch self {
         case .noError:              return "No error"
@@ -155,6 +159,14 @@ internal enum SecureDFUResultCode : UInt8 {
     case operationFailed       = 0x0A
     case extendedError         = 0x0B
     
+    var code: UInt8 {
+        return rawValue
+    }
+    
+    var error: DFUError {
+        return DFURemoteError.secure.with(code: code)
+    }
+    
     var description: String {
         switch self {
             case .invalidCode:           return "Invalid code"
@@ -169,10 +181,6 @@ internal enum SecureDFUResultCode : UInt8 {
             case .operationFailed:       return "Operation failed"
             case .extendedError:         return "Extended error"
         }
-    }
-    
-    var code: UInt8 {
-        return rawValue
     }
 }
 
@@ -576,12 +584,10 @@ internal class SecureDFUControlPoint : NSObject, CBPeripheralDelegate, DFUCharac
         case .extendedError:
             // An extended error was received.
             logger.e("Error \(dfuResponse.error!.code): \(dfuResponse.error!.description)")
-            // The returned errod code is incremented by 20 to match Secure DFU remote codes.
-            report?(DFUError(rawValue: Int(dfuResponse.error!.code) + 20)!, dfuResponse.error!.description)
+            report?(dfuResponse.error!.error, dfuResponse.error!.description)
         default:
             logger.e("Error \(dfuResponse.status.code): \(dfuResponse.status.description)")
-            // The returned errod code is incremented by 10 to match Secure DFU remote codes.
-            report?(DFUError(rawValue: Int(dfuResponse.status.code) + 10)!, dfuResponse.status.description)
+            report?(dfuResponse.status.error, dfuResponse.status.description)
         }
     }
     

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -66,6 +66,9 @@ internal enum SecureDFUExtendedErrorCode : UInt8 {
     case verificationFailed   = 0x0C
     case insufficientSpace    = 0x0D
     
+    // Note: When more result codes are added, the corresponding DFUError
+    //       case needs to be added. See `error` property below.
+    
     var code: UInt8 {
         return rawValue
     }
@@ -211,6 +214,9 @@ internal enum SecureDFUResultCode : UInt8 {
     case operationNotPermitted = 0x08
     case operationFailed       = 0x0A
     case extendedError         = 0x0B
+    
+    // Note: When more result codes are added, the corresponding DFUError
+    //       case needs to be added. See `error` property below.
     
     var code: UInt8 {
         return rawValue

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -100,9 +100,9 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         } else {
             // The device is ready to proceed with DFU.
             
-            // Start by reading command object info to get the maximum write size.
-            peripheral.readCommandObjectInfo() // -> peripheralDidSendCommandObjectInfo(...) will be
-                                               //    called when object received.
+            // Start by selecting Command Object to get the maximum write size.
+            peripheral.selectCommandObject() // -> peripheralDidSendCommandObjectInfo(...) will be
+                                             //    called when object received.
         }
     }
     
@@ -160,7 +160,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
             sendInitPacket(fromOffset: offset) // -> peripheralDidReceiveInitPacket() will be called.
         } else {
             // PRNs are ready, check out the Data object.
-            peripheral.readDataObjectInfo() // -> peripheralDidSendDataObjectInfo(...) will be called.
+            peripheral.selectDataObject() // -> peripheralDidSendDataObjectInfo(...) will be called.
         }
     }
     
@@ -278,7 +278,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
         }
     }
     
-    func peripheralDidSendDataObjectInfo(maxLen: UInt32, offset: UInt32, crc: UInt32 ) {
+    func peripheralDidSendDataObjectInfo(maxLen: UInt32, offset: UInt32, crc: UInt32) {
         self.offset = offset
         
         // This is the initial state, if ranges aren't set, assume this is the first

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -156,11 +156,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     }
     
     /**
-     Reads Data Object Info in order to obtain current status and the maximum
-     object size.
+     Selects Data Object. As a result, the current status and the maximum
+     object size is returned.
      */
-    func readDataObjectInfo() {
-        dfuService?.readDataObjectInfo(
+    func selectDataObject() {
+        dfuService?.selectDataObject(
             onReponse: { [weak self] response in
                 guard let self = self else { return }
                 guard response.maxSize! > 0 else {
@@ -178,11 +178,11 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     }
     
     /**
-     Reads Command Object Info in order to obtain current status and the maximum
-     object size.
+     Selects Command Object. As a result, the current status and the maximum
+     object size is returned.
      */
-    func readCommandObjectInfo() {
-        dfuService?.readCommandObjectInfo(
+    func selectCommandObject() {
+        dfuService?.selectCommandObject(
             onReponse: { [weak self] response in
                 guard let self = self else { return }
                 guard response.maxSize! > 0 else {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -164,7 +164,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             onReponse: { response in
                 guard let maxSize = response.maxSize, maxSize > 0 else {
                     self.defaultErrorCallback(DFUError.unsupportedResponse,
-                                              "Received Maximum Response Size smaller than 1 byte.")
+                                              "Received invalid maxSize (nil or smaller than 1).")
                     return
                 }
                 self.delegate?.peripheralDidSendDataObjectInfo(maxLen: maxSize,

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -186,7 +186,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                 guard response.maxSize! > 0 else {
                     self.logger.e("Invalid Command Object Max size = 0 received (expected > 0, typically 256 bytes)")
                     self.delegate?.error(.unsupportedResponse,
-                                         didOccurWithMessage: "Received max size = 0, expected 256")
+                                         didOccurWithMessage: "Received max object size = 0, expected 256")
                     return
                 }
                 self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response.maxSize!,

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -329,4 +329,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             }
         )
     }
+    
+    override func resetDevice() {
+        guard let dfuService = dfuService, dfuService.supportsReset() else {
+            super.resetDevice()
+            return
+        }
+        dfuService.sendReset(onError: defaultErrorCallback)
+    }
 }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -162,7 +162,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func readDataObjectInfo() {
         dfuService?.readDataObjectInfo(
             onReponse: { response in
-                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response.maxSize!,
+                guard let maxSize = response.maxSize, maxSize > 0 else {
+                    self.defaultErrorCallback(DFUError.unsupportedResponse,
+                                              "Received Maximum Response Size smaller than 1 byte.")
+                    return
+                }
+                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: maxSize,
                                                                offset: response.offset!,
                                                                crc: response.crc!)
             },

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -162,12 +162,13 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func readDataObjectInfo() {
         dfuService?.readDataObjectInfo(
             onReponse: { response in
-                guard let maxSize = response.maxSize, maxSize > 0 else {
-                    self.defaultErrorCallback(DFUError.unsupportedResponse,
-                                              "Received invalid maxSize (nil or smaller than 1).")
+                guard response.maxSize! > 0 else {
+                    self.logger.e("Invalid Data Object Max size = 0 received (expected > 0, typically 4096 bytes)")
+                    self.delegate?.error(.unsupportedResponse,
+                                         didOccurWithMessage: "Received max object size = 0, expected 4096")
                     return
                 }
-                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: maxSize,
+                self.delegate?.peripheralDidSendDataObjectInfo(maxLen: response.maxSize!,
                                                                offset: response.offset!,
                                                                crc: response.crc!)
             },
@@ -182,6 +183,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
     func readCommandObjectInfo() {
         dfuService?.readCommandObjectInfo(
             onReponse: { response in
+                guard response.maxSize! > 0 else {
+                    self.logger.e("Invalid Command Object Max size = 0 received (expected > 0, typically 256 bytes)")
+                    self.delegate?.error(.unsupportedResponse,
+                                         didOccurWithMessage: "Received max size = 0, expected 256")
+                    return
+                }
                 self.delegate?.peripheralDidSendCommandObjectInfo(maxLen: response.maxSize!,
                                                                   offset: response.offset!,
                                                                   crc: response.crc!)

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -74,7 +74,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func enableControlPoint() {
         dfuService?.enableControlPoint(
-            onSuccess: { self.delegate?.peripheralDidEnableControlPoint() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidEnableControlPoint() },
             onError: defaultErrorCallback
         )
     }
@@ -115,16 +115,16 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         possibleDisconnectionOnSettingAlternativeName = name != nil
         
         dfuService.jumpToBootloaderMode(withAlternativeAdvertisingName: name,
-            onSuccess: {
-                self.jumpingToBootloader = true
-                self.possibleDisconnectionOnSettingAlternativeName = false
+            onSuccess: { [weak self] in
+                self?.jumpingToBootloader = true
+                self?.possibleDisconnectionOnSettingAlternativeName = false
                 // The device will now disconnect and
                 // `centralManager(_:didDisconnectPeripheral:error)` will be called.
             },
-            onError: { error, message in
-                self.jumpingToBootloader = false
-                self.possibleDisconnectionOnSettingAlternativeName = false
-                self.delegate?.error(error, didOccurWithMessage: message)
+            onError: { [weak self] error, message in
+                self?.jumpingToBootloader = false
+                self?.possibleDisconnectionOnSettingAlternativeName = false
+                self?.delegate?.error(error, didOccurWithMessage: message)
             }
         )
     }
@@ -161,7 +161,8 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func readDataObjectInfo() {
         dfuService?.readDataObjectInfo(
-            onReponse: { response in
+            onReponse: { [weak self] response in
+                guard let self = self else { return }
                 guard response.maxSize! > 0 else {
                     self.logger.e("Invalid Data Object Max size = 0 received (expected > 0, typically 4096 bytes)")
                     self.delegate?.error(.unsupportedResponse,
@@ -182,7 +183,8 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func readCommandObjectInfo() {
         dfuService?.readCommandObjectInfo(
-            onReponse: { response in
+            onReponse: { [weak self] response in
+                guard let self = self else { return }
                 guard response.maxSize! > 0 else {
                     self.logger.e("Invalid Command Object Max size = 0 received (expected > 0, typically 256 bytes)")
                     self.delegate?.error(.unsupportedResponse,
@@ -204,7 +206,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func createDataObject(withLength length: UInt32) {
         dfuService?.createDataObject(withLength: length,
-             onSuccess: { self.delegate?.peripheralDidCreateDataObject() },
+             onSuccess: { [weak self] in self?.delegate?.peripheralDidCreateDataObject() },
              onError: defaultErrorCallback
         )
     }
@@ -216,7 +218,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func createCommandObject(withLength length: UInt32) {
         dfuService?.createCommandObject(withLength: length,
-            onSuccess: { self.delegate?.peripheralDidCreateCommandObject() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidCreateCommandObject() },
             onError: defaultErrorCallback
         )
     }
@@ -234,7 +236,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                         on queue: DispatchQueue) {
         dfuService?.sendNextObject(from: range, of: firmware,
             andReportProgressTo: progress, on: queue,
-            onSuccess: { self.delegate?.peripheralDidReceiveObject() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidReceiveObject() },
             onError: defaultErrorCallback
         )
     }
@@ -251,7 +253,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func setPRNValue(_ newValue: UInt16 = 0) {
         dfuService?.setPacketReceiptNotificationValue(newValue,
-            onSuccess: { self.delegate?.peripheralDidSetPRNValue() },
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidSetPRNValue() },
             onError: defaultErrorCallback
         )
     }
@@ -278,9 +280,9 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
      */
     func sendCalculateChecksumCommand() {
         dfuService?.calculateChecksumCommand(
-            onSuccess: { response in
-                self.delegate?.peripheralDidSendChecksum(offset: response.offset!,
-                                                         crc: response.crc!)
+            onSuccess: { [weak self] response in
+                self?.delegate?.peripheralDidSendChecksum(offset: response.offset!,
+                                                          crc: response.crc!)
             },
             onError: defaultErrorCallback
         )
@@ -301,8 +303,9 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                             andActivateIf complete: Bool = false) {
         activating = complete
         dfuService?.executeCommand(
-            onSuccess: { self.delegate?.peripheralDidExecuteObject() },
-            onError: { error, message in
+            onSuccess: { [weak self] in self?.delegate?.peripheralDidExecuteObject() },
+            onError: { [weak self] error, message in
+                guard let self = self else { return }
                 self.activating = false
                 
                 // In SDK 15.2 (and perhaps 15.x), the DFU target may reoprt only full pages

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -199,15 +199,15 @@ import CoreBluetooth
     }
     
     /**
-     Reads Command Object Info. Result it reported using callbacks.
+     Selects the Command Object. Result it reported using callbacks.
      
      - parameter response: Method called when the response was received.
      - parameter report:   Method called when an error occurred.
      */
-    func readCommandObjectInfo(onReponse response: @escaping SecureDFUResponseCallback,
-                               onError report: @escaping ErrorCallback) {
+    func selectCommandObject(onReponse response: @escaping SecureDFUResponseCallback,
+                             onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic?.send(.readCommandObjectInfo,
+            dfuControlPointCharacteristic?.send(.selectCommandObject,
                                                 onResponse: response, onError: report)
         } else {
             sendReset(onError: report)
@@ -215,15 +215,15 @@ import CoreBluetooth
     }
     
     /**
-     Reads object info Data. Result it reported using callbacks.
+     Selects the Data Object. Result it reported using callbacks.
      
      - parameter response: Method called when the response was received.
      - parameter report:   Method called when an error occurred.
      */
-    func readDataObjectInfo(onReponse response: @escaping SecureDFUResponseCallback,
-                            onError report: @escaping ErrorCallback) {
+    func selectDataObject(onReponse response: @escaping SecureDFUResponseCallback,
+                          onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic?.send(.readDataObjectInfo,
+            dfuControlPointCharacteristic?.send(.selectDataObject,
                                                 onResponse: response, onError: report)
         } else {
             sendReset(onError: report)

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -47,6 +47,17 @@ import CoreBluetooth
     private let service                       : CBService
     private var dfuPacketCharacteristic       : SecureDFUPacket?
     private var dfuControlPointCharacteristic : SecureDFUControlPoint?
+    
+    /// This method returns true if DFU Control Point characteristc has been discovered.
+    /// A device without this characteristic is not supported and even can't be resetted
+    /// by sending a Reset command.
+    internal func supportsReset() -> Bool {
+        // The Abort (0x0C) command has been added to DFU bootloader in SDK 15.
+        // https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/lib_dfu_transport.html?cp=8_5_3_3_5_2
+        // For earlier SDKs there is no way to reset the bootloader other than
+        // disconnecting and waiting for it to time out after few minutes.
+        return dfuControlPointCharacteristic != nil
+    }
 
     private var paused  = false
     private var aborted = false
@@ -55,7 +66,7 @@ import CoreBluetooth
     private var success          : Callback?
     /// A temporary callback used to report an operation error.
     private var report           : ErrorCallback?
-    /// A temporaty callback used to report progress status.
+    /// A temporary callback used to report progress status.
     private var progressDelegate : DFUProgressDelegate?
     private var progressQueue    : DispatchQueue?
     
@@ -323,10 +334,19 @@ import CoreBluetooth
      
      - parameter report: A callback called when writing characteristic failed.
      */
-    private func sendReset(onError report: @escaping ErrorCallback) {
+    func sendReset(onError report: @escaping ErrorCallback) {
         aborted = true
-        // There is no command to reset a Secure DFU device. We can just disconnect.
-        targetPeripheral?.disconnect()
+        // Upon sending the Abort request the device will immediately reboot in application
+        // mode. There will be no notification with status success returned.
+        dfuControlPointCharacteristic?.send(.abort,
+            onSuccess: nil, // Device will disconnected immediately.
+            onError: { [weak self] _, _ in
+                // Seems like the Abort request is not supported (indicating SDK 12-14).
+                // We can just disconnect. The bootloader should reset to app mode after
+                // a timeout.
+                self?.targetPeripheral?.disconnect()
+            }
+        )
     }
     
     //MARK: - Packet commands

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -49,8 +49,7 @@ import CoreBluetooth
     private var dfuControlPointCharacteristic : SecureDFUControlPoint?
     
     /// This method returns true if DFU Control Point characteristc has been discovered.
-    /// A device without this characteristic is not supported and even can't be resetted
-    /// by sending a Reset command.
+    /// A device without this characteristic is not supported and can only be disconnected.
     internal func supportsReset() -> Bool {
         // The Abort (0x0C) command has been added to DFU bootloader in SDK 15.
         // https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/lib_dfu_transport.html?cp=8_5_3_3_5_2


### PR DESCRIPTION
This version introduces the following features:
- New feature: #447 - Abort command may be sent in case of an error to a DFU bootloader from SDK 15 or newer, to quickly reset it into application mode.
- Improvement: #442 
- Improvement: #445 
- Bug fix: #443 and #444 
- Bug fix: #446 
- Minor: #448

Besides:
- Read Object Info was renamed to Select Object, to be more inline with Secure DFU specification cb29e88a06944ba559e2015cef61d4a4e677330c