### PR TITLE
Invalid Opcode Response Detection to prevent Crash

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -163,6 +163,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         dfuService?.selectDataObject(
             onReponse: { [weak self] response in
                 guard let self = self else { return }
+                guard response.requestOpCode == .selectObject else {
+                    self.logger.e("Invalid Command Object Opcode = \(response.requestOpCode) received (expected \(SecureDFUOpCode.selectObject))")
+                    self.delegate?.error(.unsupportedResponse,
+                                         didOccurWithMessage: "Received requestOpCode \(response.requestOpCode), expected \(SecureDFUOpCode.selectObject)")
+                    return
+                }
                 guard response.maxSize! > 0 else {
                     self.logger.e("Invalid Data Object Max size = 0 received (expected > 0, typically 4096 bytes)")
                     self.delegate?.error(.unsupportedResponse,
@@ -185,6 +191,12 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
         dfuService?.selectCommandObject(
             onReponse: { [weak self] response in
                 guard let self = self else { return }
+                guard response.requestOpCode == .selectObject else {
+                    self.logger.e("Invalid Command Object Opcode = \(response.requestOpCode) received (expected \(SecureDFUOpCode.selectObject))")
+                    self.delegate?.error(.unsupportedResponse,
+                                         didOccurWithMessage: "Received requestOpCode \(response.requestOpCode), expected \(SecureDFUOpCode.selectObject)")
+                    return
+                }
                 guard response.maxSize! > 0 else {
                     self.logger.e("Invalid Command Object Max size = 0 received (expected > 0, typically 256 bytes)")
                     self.delegate?.error(.unsupportedResponse,


### PR DESCRIPTION
The following Stack Trace happens in nRF Connect 2.5.1:
```
Thread 13 name:
Thread 13 Crashed:
0   nRF-Connect                   	0x0000000100f77410 closure #1 in SecureDFUPeripheral.selectCommandObject() + 384 (SecureDFUPeripheral.swift:0)
1   nRF-Connect                   	0x0000000100f772d8 closure #1 in SecureDFUPeripheral.selectCommandObject() + 72 (SecureDFUPeripheral.swift:187)
2   nRF-Connect                   	0x0000000100f6d500 specialized SecureDFUControlPoint.peripheral(_:didUpdateValueFor:error:) + 1436 (SecureDFUControlPoint.swift:621)
3   nRF-Connect                   	0x0000000100f6bc8c @objc SecureDFUControlPoint.peripheral(_:didUpdateNotificationStateFor:error:) + 108
4   CoreBluetooth                 	0x00000001be97b64c -[CBPeripheral handleAttributeEvent:args:attributeSelector:delegateSelector:delegateFlag:] + 188 (CBPeripheral.m:804)
5   CoreBluetooth                 	0x00000001be97b7f0 -[CBPeripheral handleCharacteristicEvent:characteristicSelector:delegateSelector:delegateFlag:] + 124 (CBPeripheral.m:826)
6   CoreBluetooth                 	0x00000001be977994 -[CBPeripheral handleMsg:args:] + 600 (CBPeripheral.m:233)
7   CoreBluetooth                 	0x00000001be961af0 -[CBCentralManager handleMsg:args:] + 192 (CBCentralManager.m:1451)
8   CoreBluetooth                 	0x00000001be9a22b8 -[CBManager xpcConnectionDidReceiveMsg:args:] + 208 (CBManager.m:428)
9   CoreBluetooth                 	0x00000001be9916c0 __30-[CBXpcConnection _handleMsg:]_block_invoke + 68 (CBXpcConnection.m:370)
10  libdispatch.dylib             	0x000000019fe16e68 _dispatch_call_block_and_release + 32 (init.c:1517)
11  libdispatch.dylib             	0x000000019fe18a2c _dispatch_client_callout + 20 (object.m:560)
12  libdispatch.dylib             	0x000000019fe20124 _dispatch_lane_serial_drain + 668 (inline_internal.h:2622)
13  libdispatch.dylib             	0x000000019fe20cb4 _dispatch_lane_invoke + 444 (queue.c:3944)
14  libdispatch.dylib             	0x000000019fe20000 _dispatch_lane_serial_drain + 376 (inline_internal.h:0)
15  libdispatch.dylib             	0x000000019fe20cb4 _dispatch_lane_invoke + 444 (queue.c:3944)
16  libdispatch.dylib             	0x000000019fe20000 _dispatch_lane_serial_drain + 376 (inline_internal.h:0)
17  libdispatch.dylib             	0x000000019fe20c80 _dispatch_lane_invoke + 392 (queue.c:3944)
18  libdispatch.dylib             	0x000000019fe2b500 _dispatch_workloop_worker_thread + 648 (queue.c:6732)
19  libsystem_pthread.dylib       	0x000000021110a0bc _pthread_wqthread + 288 (pthread.c:2599)
20  libsystem_pthread.dylib       	0x0000000211109e5c start_wqthread + 8
```
Quick analysis shows we're force-unwrapping `SecureDFUResponse`'s `maxSize`, `offset` and `crc`. The obvious fix would be to just guard those properties and, if they're not there, to report an Error. But the code-path leading to this code getting executed suggests we might be executing the callback for the wrong type of response, so we're going to sacrifice killing the bug in exchange for perhaps learning new information regarding the root cause of the issue.