### PR TITLE
Modernised DFU Manifest

### DIFF
--- a/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/Manifest.swift
+++ b/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/Manifest.swift
@@ -30,16 +30,25 @@
 
 import Foundation
 
-class Manifest: NSObject {
+// MARK: - ManifestJSONContainer
+
+struct ManifestJSONContainer: Codable {
     
-    // MARK: - Properties
+    let manifest: Manifest
+}
+
+// MARK: - Manifest
+
+struct Manifest: Codable {
     
-    var application: ManifestFirmwareInfo?
-    var softdevice:  ManifestFirmwareInfo?
-    var bootloader:  ManifestFirmwareInfo?
-    var softdeviceBootloader: SoftdeviceBootloaderInfo?
+    // MARK: Properties
     
-    var valid: Bool {
+    let application: ManifestFirmwareInfo?
+    let softdevice:  ManifestFirmwareInfo?
+    let bootloader:  ManifestFirmwareInfo?
+    let softdeviceBootloader: SoftdeviceBootloaderInfo?
+    
+    var isValid: Bool {
         // The manifest.json file may specify only:
         // 1. a softdevice, a bootloader, or both combined (with, or without an app)
         // 2. only the app
@@ -53,52 +62,12 @@ class Manifest: NSObject {
         return count == 1 || (count == 0 && hasApplication)
     }
     
-    // MARK: - Init
+    // MARK: Coding Keys
     
-    init(withJsonString aString: String) {
-        do {
-            guard let data = aString.data(using: String.Encoding.utf8),
-                  let aDictionary = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? Dictionary<String, AnyObject> else {
-                throw Error.unableToParseJSON(description: "Unable to Decode root JSON Dictionary.")
-            }
-            
-            guard let mainObject = aDictionary["manifest"] as? Dictionary<String, AnyObject> else {
-                throw Error.unableToParseJSON(description: "Manifest JSON Dictionary could not be found.")
-            }
-            
-            if let applicationDictionary = mainObject["application"] as? Dictionary<String, AnyObject> {
-                self.application = ManifestFirmwareInfo(withDictionary: applicationDictionary)
-            }
-            
-            if let bootloaderDictionary = mainObject["softdevice_bootloader"] as? Dictionary<String, AnyObject> {
-                self.softdeviceBootloader = SoftdeviceBootloaderInfo(withDictionary: bootloaderDictionary)
-            }
-            
-            if let softDeviceDictionary = mainObject["softdevice"] as? Dictionary<String, AnyObject> {
-                self.softdevice = ManifestFirmwareInfo(withDictionary: softDeviceDictionary)
-            }
-            
-            if let bootloaderDictionary = mainObject["bootloader"] as? Dictionary<String, AnyObject> {
-                self.bootloader = ManifestFirmwareInfo(withDictionary: bootloaderDictionary)
-            }
-        } catch {
-            print("Encountered an error while parsing manifest.json: \(error.localizedDescription)")
-        }        
-    }
-}
-
-// MARK: - Manifest.Error
-
-extension Manifest {
-    
-    enum Error: Swift.Error, LocalizedError {
-        case unableToParseJSON(description: String)
-        
-        var errorDescription: String? {
-            switch self {
-            case .unableToParseJSON(let description):
-                return description
-            }
-        }
+    enum CodingKeys: String, CodingKey {
+        case application = "application"
+        case softdeviceBootloader = "softdevice_bootloader"
+        case softdevice = "softdevice"
+        case bootloader = "bootloader"
     }
 }

--- a/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/ManifestFirmwareInfo.swift
+++ b/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/ManifestFirmwareInfo.swift
@@ -30,20 +30,30 @@
 
 import Foundation
 
-class ManifestFirmwareInfo: NSObject {
-    var binFile: String? = nil
-    var datFile: String? = nil
+// MARK: - ManifestFirmware
+
+protocol ManifestFirmware {
     
-    var valid: Bool {
+    var binFile: String? { get }
+    var datFile: String? { get }
+}
+
+extension ManifestFirmware {
+    
+    var isValid: Bool {
         return binFile != nil // && datFile != nil The init packet was not required before SDK 7.1
     }
+}
+
+// MARK: - ManifestFirmwareInfo
+
+struct ManifestFirmwareInfo: ManifestFirmware, Codable {
     
-    init(withDictionary aDictionary : Dictionary<String, AnyObject>) {
-        if aDictionary.keys.contains("bin_file") {
-            binFile = String(describing: aDictionary["bin_file"]!)
-        }
-        if aDictionary.keys.contains("dat_file") {
-            datFile = String(describing: aDictionary["dat_file"]!)
-        }
+    let binFile: String?
+    let datFile: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case binFile = "bin_file"
+        case datFile = "dat_file"
     }
 }

--- a/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/SoftdeviceBootloaderInfo.swift
+++ b/iOSDFULibrary/Classes/Utilities/DFUPackage/Manifest/SoftdeviceBootloaderInfo.swift
@@ -30,17 +30,53 @@
 
 import Foundation
 
-class SoftdeviceBootloaderInfo: ManifestFirmwareInfo {
-    var blSize: UInt32 = 0
-    var sdSize: UInt32 = 0
+// MARK: - SoftdeviceBootloaderInfo
+
+struct SoftdeviceBootloaderInfo: ManifestFirmware, Codable {
     
-    override init(withDictionary aDictionary : Dictionary<String, AnyObject>) {
-        super.init(withDictionary: aDictionary)
-        if aDictionary.keys.contains("bl_size") {
-            blSize = (aDictionary["bl_size"]!).uint32Value
-        }
-        if aDictionary.keys.contains("sd_size") {
-            sdSize = (aDictionary["sd_size"]!).uint32Value
+    // MARK: Properties
+    
+    let binFile: String?
+    let datFile: String?
+    let metadata: Metadata?
+    let _blSize: UInt32?
+    let _sdSize: UInt32?
+    
+    // MARK: Computed Properties
+    
+    var blSize: UInt32 {
+        return metadata?.blSize ?? _blSize ?? 0
+    }
+    
+    var sdSize: UInt32 {
+        return metadata?.sdSize ?? _sdSize ?? 0
+    }
+    
+    // MARK: CodingKeys
+    
+    enum CodingKeys: String, CodingKey {
+        case binFile = "bin_file"
+        case datFile = "dat_file"
+        case metadata = "info_read_only_metadata"
+        case _blSize = "bl_size"
+        case _sdSize = "sd_size"
+    }
+}
+
+// MARK: - SoftdeviceBootloaderInfo.SecureMetadata
+
+extension SoftdeviceBootloaderInfo {
+
+    struct Metadata: Codable {
+
+        let blSize: UInt32
+        let sdSize: UInt32
+
+        // MARK: CodingKeys
+
+        enum CodingKeys: String, CodingKey {
+            case blSize = "bl_size"
+            case sdSize = "sd_size"
         }
     }
 }


### PR DESCRIPTION
Instead of NSObject, so Objective-C classes, these are now structs. They're also Codable(s), so we don't need to do the JSON dance ourselves. I'm sure there are many more parts inside the library that deserve this same treatment, but we can't do it all at once. This is a small step.