### PR TITLE
Ignore checksum response when selecting an object

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUControlPoint.swift
@@ -49,6 +49,24 @@ internal enum SecureDFUOpCode : UInt8 {
     var code: UInt8 {
         return rawValue
     }
+    
+    var description: String {
+        switch self {
+        case .getProtocolVersion: return "Get Protocol Version"
+        case .createObject:       return "Create Object"
+        case .setPRNValue:        return "Set PRN Value"
+        case .calculateChecksum:  return "Calculate Checksum"
+        case .execute:            return "Execute"
+        case .selectObject:       return "Select Object"
+        case .getMtu:             return "Get MTU"
+        case .write:              return "Write"
+        case .ping:               return "Ping"
+        case .getHwVersion:       return "Get Hw Version"
+        case .getFwVersion:       return "Get Fw Version"
+        case .abort:              return "Abort"
+        case .responseCode:       return "Response Code"
+        }
+    }
 }
 
 internal enum SecureDFUExtendedErrorCode : UInt8 {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -164,9 +164,9 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             onReponse: { [weak self] response in
                 guard let self = self else { return }
                 guard response.requestOpCode == .selectObject else {
-                    self.logger.e("Invalid Command Object Opcode = \(response.requestOpCode) received (expected \(SecureDFUOpCode.selectObject))")
+                    self.logger.e("Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
                     self.delegate?.error(.unsupportedResponse,
-                                         didOccurWithMessage: "Received requestOpCode \(response.requestOpCode), expected \(SecureDFUOpCode.selectObject)")
+                                         didOccurWithMessage: "Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
                     return
                 }
                 guard response.maxSize! > 0 else {
@@ -192,9 +192,9 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             onReponse: { [weak self] response in
                 guard let self = self else { return }
                 guard response.requestOpCode == .selectObject else {
-                    self.logger.e("Invalid Command Object Opcode = \(response.requestOpCode) received (expected \(SecureDFUOpCode.selectObject))")
+                    self.logger.e("Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
                     self.delegate?.error(.unsupportedResponse,
-                                         didOccurWithMessage: "Received requestOpCode \(response.requestOpCode), expected \(SecureDFUOpCode.selectObject)")
+                                         didOccurWithMessage: "Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
                     return
                 }
                 guard response.maxSize! > 0 else {

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Peripheral/SecureDFUPeripheral.swift
@@ -165,8 +165,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                 guard let self = self else { return }
                 guard response.requestOpCode == .selectObject else {
                     self.logger.e("Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
-                    self.delegate?.error(.unsupportedResponse,
-                                         didOccurWithMessage: "Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
+                    self.throwErrorIfNotChecksumResponse(response)
                     return
                 }
                 guard response.maxSize! > 0 else {
@@ -193,8 +192,7 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
                 guard let self = self else { return }
                 guard response.requestOpCode == .selectObject else {
                     self.logger.e("Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
-                    self.delegate?.error(.unsupportedResponse,
-                                         didOccurWithMessage: "Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
+                    self.throwErrorIfNotChecksumResponse(response)
                     return
                 }
                 guard response.maxSize! > 0 else {
@@ -209,6 +207,21 @@ internal class SecureDFUPeripheral : BaseCommonDFUPeripheral<SecureDFUExecutor, 
             },
             onError: defaultErrorCallback
         )
+    }
+    
+    /**
+     https://github.com/NordicSemiconductor/IOS-DFU-Library/issues/465
+     indicates, that sometimes a Checksum response is received here.
+     It may be a lost PRN, or an invalid response. We don't know yet.
+     If you encounter this log, please report to the mentioned issue
+     providing logs. Thank you!
+     Let's hope for the best and wait for the proper response.
+     */
+    private func throwErrorIfNotChecksumResponse(_ response: SecureDFUResponse) {
+        if response.requestOpCode != .calculateChecksum {
+            self.delegate?.error(.unsupportedResponse,
+                                 didOccurWithMessage: "Invalid response received (\(response.description), expected \(SecureDFUOpCode.selectObject.description))")
+        }
     }
     
     /**

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Services/SecureDFUService.swift
@@ -301,7 +301,7 @@ import CoreBluetooth
     func calculateChecksumCommand(onSuccess response: @escaping SecureDFUResponseCallback,
                                   onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic?.send(SecureDFURequest.calculateChecksumCommand,
+            dfuControlPointCharacteristic?.send(.calculateChecksumCommand,
                                                 onResponse: response, onError: report)
         } else {
             sendReset(onError: report)
@@ -317,7 +317,7 @@ import CoreBluetooth
     func executeCommand(onSuccess success: @escaping Callback,
                         onError report: @escaping ErrorCallback) {
         if !aborted {
-            dfuControlPointCharacteristic?.send(SecureDFURequest.executeCommand,
+            dfuControlPointCharacteristic?.send(.executeCommand,
                                                 onSuccess: success, onError: report)
         } else {
             sendReset(onError: report)


### PR DESCRIPTION
This PR fixes #465. Perhaps.

When a response to `.calculateChecksum` is received instead of `.selectObject`, the library will keep waiting for the proper response. It will just log a message, but won't fail the DFU. In #480 @dinesharjani introduced a check for the op code, but was reporting an error. As we don't yet know what is the better approach, let's first try waiting, hoping that we will get more logs from desperate users (sorry!).