### PR TITLE
Bugfix: Resuming Init object

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -461,12 +461,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
             return
         }
         let initPacketLength = UInt32(initPacket.count)
-        guard Int(offset) < Int(initPacketLength - offset) else {
-            error(.invalidInternalState, didOccurWithMessage:
-                  "Asset offset (\(offset)) < initPacketLength (\(initPacketLength)) - offset (\(offset)) failed")
-            return
-        }
-        let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength - offset))
+        let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength))
         
         // Send following bytes of init packet (offset may be 0).
         peripheral.sendInitPacket(data) // -> peripheralDidReceiveInitPacket() will be called.

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -435,12 +435,12 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
      - returns: `True` if CRCs are identical, `false` otherwise.
      */
     private func verifyCRC(for data: Data, andPacketOffset offset: UInt32, matches crc: UInt32) -> Bool {
-        // Edge case where a different objcet might be flashed with a biger init file.
-        if offset > UInt32(data.count) {
+        // Edge case where a different object might be flashed with a bigger init file.
+        guard offset <= UInt32(data.count) else {
             return false
         }
         // Get data form 0 up to the offset the peripheral has reproted.
-        let offsetData : Data = (data.subdata(in: 0 ..< Int(offset)))
+        let offsetData = data.subdata(in: 0 ..< Int(offset))
         let calculatedCRC = crc32(data: offsetData)
         
         // This returns true if the current data packet's CRC matches the current firmware's

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/DFU/SecureDFUExecutor.swift
@@ -457,8 +457,7 @@ internal class SecureDFUExecutor : DFUExecutor, SecureDFUPeripheralDelegate {
      */
     private func sendInitPacket(fromOffset offset: UInt32) {
         guard let initPacket = firmware.initPacket else {
-            error(.invalidInternalState, didOccurWithMessage:
-                  "Assert initPacket != nil failed")
+            error(.invalidInternalState, didOccurWithMessage: "Assert initPacket != nil failed")
             return
         }
         let initPacketLength = UInt32(initPacket.count)


### PR DESCRIPTION
This PR fixes #479, a long existing issue where the Init Object was incorrectly resumed when reported offset was > 0.

The main part of this fix is here:
```diff
-let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength - offset))
+let data = initPacket.subdata(in: Int(offset) ..< Int(initPacketLength))
```
Associated assert was also removed.