### PR TITLE
Breaking: Creating `DFUFirmware` may now throw an error

### DIFF
--- a/Example/iOSDFULibrary/DFU Test Performer/DFUTestSet.swift
+++ b/Example/iOSDFULibrary/DFU Test Performer/DFUTestSet.swift
@@ -34,7 +34,6 @@ import CoreBluetooth
 
 enum DFUTestError : Error {
     case fileNotFound
-    case invalidFirmware
 }
 
 typealias AdvertisingData = [String : Any]
@@ -82,10 +81,9 @@ class FilterBy {
 
 class Option {
     
-    static let prn : (UInt16) -> ServiceModifier = {
-        aPRNValue in
+    static let prn : (UInt16) -> ServiceModifier = { prn in
         return {
-            initiator in initiator.packetReceiptNotificationParameter = aPRNValue
+            initiator in initiator.packetReceiptNotificationParameter = prn
         }
     }
     
@@ -97,14 +95,10 @@ class Option {
 extension DFUFirmware {
     
     private static func from(urlToZipFile url: URL?, type: DFUFirmwareType) throws -> DFUFirmware {
-        guard url != nil else {
+        guard let url = url else {
             throw DFUTestError.fileNotFound
         }
-        let firmware = DFUFirmware(urlToZipFile: url!, type: type)
-        guard firmware != nil else {
-            throw DFUTestError.invalidFirmware
-        }
-        return firmware!
+        return try DFUFirmware(urlToZipFile: url, type: type)
     }
     
     static func from(zip name: String, locatedIn subdirectory: String) throws -> DFUFirmware {

--- a/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
+++ b/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
@@ -165,8 +165,10 @@ extension DFUFirmwareError : LocalizedError {
      - parameter zipFile: The Distribution packet (ZIP) data.
      
      - returns: The DFU firmware object or `nil` in case of an error.
-     - throws: `DFUFirmwareError` if the file is invalid, or
-               `DFUStreamZipError` if creating a Zip stream failed.
+     - throws: `DFUFirmwareError` if the file is invalid,
+               `DFUStreamZipError` if creating a Zip stream failed,
+               or an error in the Cocoa domain, if the data cannot be written
+               to a temporary location.
      */
     @objc convenience public init(zipFile: Data) throws {
         try self.init(zipFile: zipFile, type: DFUFirmwareType.softdeviceBootloaderApplication)

--- a/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
+++ b/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
@@ -54,6 +54,26 @@ import Foundation
     case softdeviceBootloaderApplication = 7
 }
 
+/**
+ An error thrown when instantiating a `DFUFirmware` type from an invalid file.
+ */
+public struct DFUFirmwareError : Error {
+    public enum FileType {
+        case zip
+        case binOrHex
+        case dat
+    }
+    public let type: FileType
+}
+
+extension DFUFirmwareError : LocalizedError {
+    
+    public var errorDescription: String? {
+        return NSLocalizedString("The \(type) file is invalid", comment: "")
+    }
+    
+}
+
 /// The DFUFirmware object wraps the firmware file.
 @objc public class DFUFirmware : NSObject, DFUStream {
     internal let stream: DFUStream
@@ -101,10 +121,12 @@ import Foundation
      - parameter urlToZipFile: URL to the Distribution packet (ZIP).
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUFirmwareError` if the file is invalid, or
+               `DFUStreamZipError` if creating a Zip stream failed.
      */
-    @objc convenience public init?(urlToZipFile: URL) {
-        self.init(urlToZipFile: urlToZipFile,
-                  type: DFUFirmwareType.softdeviceBootloaderApplication)
+    @objc convenience public init(urlToZipFile: URL) throws {
+        try self.init(urlToZipFile: urlToZipFile,
+                      type: DFUFirmwareType.softdeviceBootloaderApplication)
     }
     
     /**
@@ -117,24 +139,20 @@ import Foundation
      - parameter type:         The type of the firmware to use.
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUFirmwareError` if the file is invalid, or
+               `DFUStreamZipError` if creating a Zip stream failed.
      */
-    @objc public init?(urlToZipFile: URL, type: DFUFirmwareType) {
+    @objc public init(urlToZipFile: URL, type: DFUFirmwareType) throws {
         fileUrl = urlToZipFile
         fileName = urlToZipFile.lastPathComponent
         
         // Quickly check if it's a ZIP file
         let ext = urlToZipFile.pathExtension
         if ext.caseInsensitiveCompare("zip") != .orderedSame {
-            NSLog("\(fileName!) is not a ZIP file")
-            return nil
+            throw DFUFirmwareError(type: .zip)
         }
         
-        do {
-            stream = try DFUStreamZip(urlToZipFile: urlToZipFile, type: type)
-        } catch let error as NSError {
-            NSLog("Error while creating ZIP stream: \(error.localizedDescription)")
-            return nil
-        }
+        stream = try DFUStreamZip(urlToZipFile: urlToZipFile, type: type)
         super.init()
     }
     
@@ -147,9 +165,11 @@ import Foundation
      - parameter zipFile: The Distribution packet (ZIP) data.
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUFirmwareError` if the file is invalid, or
+               `DFUStreamZipError` if creating a Zip stream failed.
      */
-    @objc convenience public init?(zipFile: Data) {
-        self.init(zipFile: zipFile, type: DFUFirmwareType.softdeviceBootloaderApplication)
+    @objc convenience public init(zipFile: Data) throws {
+        try self.init(zipFile: zipFile, type: DFUFirmwareType.softdeviceBootloaderApplication)
     }
     
     /**
@@ -162,17 +182,15 @@ import Foundation
      - parameter type:    The type of the firmware to use.
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUFirmwareError` if the file is invalid,
+               `DFUStreamZipError` if creating a Zip stream failed,
+               or an error in the Cocoa domain, if the data cannot be written
+               to a temporary location.
      */
-    @objc public init?(zipFile: Data, type: DFUFirmwareType) {
+    @objc public init(zipFile: Data, type: DFUFirmwareType) throws {
         fileUrl = nil
         fileName = nil
-        
-        do {
-            stream = try DFUStreamZip(zipFile: zipFile, type: type)
-        } catch let error as NSError {
-            NSLog("Error while creating ZIP stream: \(error.localizedDescription)")
-            return nil
-        }
+        stream = try DFUStreamZip(zipFile: zipFile, type: type)
         super.init()
     }
     
@@ -186,8 +204,11 @@ import Foundation
      - parameter type:              The type of the firmware.
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUFirmwareError` if the file is invalid,
+               `DFUStreamHexError` if the hex file is invalid,
+               or an error in the Cocoa domain, if `url` cannot be read.
      */
-    @objc public init?(urlToBinOrHexFile: URL, urlToDatFile: URL?, type: DFUFirmwareType) {
+    @objc public init(urlToBinOrHexFile: URL, urlToDatFile: URL?, type: DFUFirmwareType) throws {
         fileUrl = urlToBinOrHexFile
         fileName = urlToBinOrHexFile.lastPathComponent
         
@@ -196,27 +217,22 @@ import Foundation
         let bin = ext.caseInsensitiveCompare("bin") == .orderedSame
         let hex = ext.caseInsensitiveCompare("hex") == .orderedSame
         guard bin || hex else {
-            NSLog("\(fileName!) is not a BIN or HEX file")
-            return nil
+            throw DFUFirmwareError(type: .binOrHex)
         }
         
         if let datUrl = urlToDatFile {
             let datExt = datUrl.pathExtension
             guard datExt.caseInsensitiveCompare("dat") == .orderedSame else {
-                NSLog("\(fileName!) is not a DAT file")
-                return nil
+                throw DFUFirmwareError(type: .dat)
             }
         }
         
         if bin {
-            stream = DFUStreamBin(urlToBinFile: urlToBinOrHexFile,
-                                  urlToDatFile: urlToDatFile, type: type)
+            stream = try DFUStreamBin(urlToBinFile: urlToBinOrHexFile,
+                                      urlToDatFile: urlToDatFile, type: type)
         } else {
-            guard let s = DFUStreamHex(urlToHexFile: urlToBinOrHexFile,
-                                       urlToDatFile: urlToDatFile, type: type) else {
-                return nil
-            }
-            stream = s
+            stream = try DFUStreamHex(urlToHexFile: urlToBinOrHexFile,
+                                      urlToDatFile: urlToDatFile, type: type)
         }
         super.init()
     }
@@ -232,10 +248,9 @@ import Foundation
      
      - returns: The DFU firmware object or `nil` in case of an error.
      */
-    @objc public init?(binFile: Data, datFile: Data?, type: DFUFirmwareType) {
+    @objc public init(binFile: Data, datFile: Data?, type: DFUFirmwareType) {
         fileUrl = nil
         fileName = nil
-        
         stream = DFUStreamBin(binFile: binFile, datFile: datFile, type: type)
         super.init()
     }
@@ -250,15 +265,12 @@ import Foundation
      - parameter type:    The type of the firmware.
      
      - returns: The DFU firmware object or `nil` in case of an error.
+     - throws: `DFUStreamHexError` if the hex file is invalid.
      */
-    @objc public init?(hexFile: Data, datFile: Data?, type: DFUFirmwareType) {
+    @objc public init(hexFile: Data, datFile: Data?, type: DFUFirmwareType) throws {
         fileUrl = nil
         fileName = nil
-        
-        guard let s = DFUStreamHex(hexFile: hexFile, datFile: datFile, type: type) else {
-            return nil
-        }
-        stream = s
+        stream = try DFUStreamHex(hexFile: hexFile, datFile: datFile, type: type)
         super.init()
     }
     

--- a/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamBin.swift
+++ b/iOSDFULibrary/Classes/Utilities/Streams/DFUStreamBin.swift
@@ -58,17 +58,30 @@ internal class DFUStreamBin : DFUStream {
         return size
     }
     
-    init(urlToBinFile: URL, urlToDatFile: URL?, type: DFUFirmwareType) {
-        binaries = try! Data(contentsOf: urlToBinFile)
+    /// Creates the stream that will allow sending the binary file.
+    ///
+    /// - parameters:
+    ///   - urlToHexFile: URL to the bin file.
+    ///   - urlToDatFile: Optional URL to the dat file. Dat file is required for nRF5 SDK 7.1+.
+    ///   - type: The firmware type.
+    /// - throws: An error in the Cocoa domain, if `url` cannot be read.
+    init(urlToBinFile: URL, urlToDatFile: URL?, type: DFUFirmwareType) throws {
+        binaries = try Data(contentsOf: urlToBinFile)
         firmwareSize = UInt32(binaries.count)
         
         if let dat = urlToDatFile {
-            initPacketBinaries = try? Data(contentsOf: dat)
+            initPacketBinaries = try Data(contentsOf: dat)
         }
         
         currentPartType = type.rawValue
     }
     
+    /// Creates the stream that will allow sending the binary file.
+    ///
+    /// - parameters:
+    ///   - binFile: The content of the bin file.
+    ///   - datFile: A content of an optional dat file. Dat file is required for nRF5 SDK 7.1+.
+    ///   - type: The firmware type.
     init(binFile: Data, datFile: Data?, type: DFUFirmwareType) {
         binaries = binFile
         firmwareSize = UInt32(binaries.count)


### PR DESCRIPTION
This PR allows to obtain a reason why creating `DFUFirmware` would fail. Before, the reason was printed in `NSLog`, but `nil` was always returned.