### PR TITLE
doc: update flutter plugin to active version

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ An unofficial library for both iOS and Android that is based on this library is 
 ### Flutter
 
 A library for both iOS and Android that is based on this library is available for Flutter: 
-[flutter-nordic-dfu](https://github.com/fengqiangboy/flutter-nordic-dfu) 
+[nordic_dfu](https://pub.dev/packages/nordic_dfu)
 
 ### Xamarin
 


### PR DESCRIPTION
The flutter plugin mentioned has been discontinued by the owner. I have forked and updated this plugin, so it would be best to mention the active version instead.