### PR TITLE
Version 4.14.0

### DIFF
--- a/Test App/Podfile.lock
+++ b/Test App/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSDFULibrary (4.13.0):
+  - iOSDFULibrary (4.14.0):
     - ZIPFoundation (= 0.9.16)
   - ZIPFoundation (0.9.16)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSDFULibrary: 33908abb48656bcf9e69f8b65fc16ac44af80690
+  iOSDFULibrary: 02e43ad33fb80b8d50f94900c5bdd807ababc15d
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
 PODFILE CHECKSUM: ae4b20f609dc65f886ce92e7f350ae5ef1fa65ca

--- a/Test App/Pods/Local Podspecs/iOSDFULibrary.podspec.json
+++ b/Test App/Pods/Local Podspecs/iOSDFULibrary.podspec.json
@@ -1,7 +1,7 @@
 {
   "name": "iOSDFULibrary",
   "module_name": "NordicDFU",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "summary": "This repository contains a library to perform Device Firmware Update on the nRF5x devices.",
   "description": "The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.",
   "homepage": "https://github.com/NordicSemiconductor/IOS-DFU-Library",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/NordicSemiconductor/IOS-DFU-Library.git",
-    "tag": "4.13.0"
+    "tag": "4.14.0"
   },
   "social_media_url": "https://twitter.com/nordictweets",
   "swift_versions": [

--- a/Test App/Pods/Manifest.lock
+++ b/Test App/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iOSDFULibrary (4.13.0):
+  - iOSDFULibrary (4.14.0):
     - ZIPFoundation (= 0.9.16)
   - ZIPFoundation (0.9.16)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  iOSDFULibrary: 33908abb48656bcf9e69f8b65fc16ac44af80690
+  iOSDFULibrary: 02e43ad33fb80b8d50f94900c5bdd807ababc15d
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
 PODFILE CHECKSUM: ae4b20f609dc65f886ce92e7f350ae5ef1fa65ca

--- a/Test App/Pods/Target Support Files/iOSDFULibrary/ResourceBundle-PrivacyInfo-iOSDFULibrary-Info.plist
+++ b/Test App/Pods/Target Support Files/iOSDFULibrary/ResourceBundle-PrivacyInfo-iOSDFULibrary-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.13.0</string>
+  <string>4.14.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Test App/Pods/Target Support Files/iOSDFULibrary/iOSDFULibrary-Info.plist
+++ b/Test App/Pods/Target Support Files/iOSDFULibrary/iOSDFULibrary-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.13.0</string>
+  <string>4.14.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
   s.module_name      = 'NordicDFU'
-  s.version          = "4.13.0"
+  s.version          = "4.14.0"
   s.summary          = "This repository contains a library to perform Device Firmware Update on the nRF5x devices."
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.


### PR DESCRIPTION
Changes in 4.14:
* Minimum iOS version set to 12.
* ZIPFoundation upgraded to 0.9.16 (0.9.17 is not available on CocoaPods: https://github.com/weichsel/ZIPFoundation/issues -> 300.
* New documentation available at https://nordicsemiconductor.github.io/IOS-DFU-Library/documentation/nordicdfu.
* Projects were refactored, folders renamed, etc.
* Module name (for CocoaPods import) was renamed from `iOSDFULibrary` to `NordicDFU` to match SPM module name.
* Carthage supports *watchOS* and *tvOS*.
* Privacy Manifest added.
* Test firmware for nRF52840 from nRF5 SDK 17.1 was added to Test App.

No functional changes in the library. If you need iOS 9+, use version 4.13.0.