### PR TITLE
Fix security vulnerability in ZipFoundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     .library(name: "NordicDFU", targets: ["NordicDFU"])
   ],
   dependencies: [
-    .package(url: "https://github.com/weichsel/ZIPFoundation", exact: "0.9.16"),
+    .package(url: "https://github.com/weichsel/ZIPFoundation", exact: "0.9.18"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [


### PR DESCRIPTION
There is the vulnerability in the current version of ZipFoundation: https://github.com/weichsel/ZIPFoundation/issues/74
Updated the package to fix the issue.