### PR TITLE
chore: add missing privacy manifests keys

### DIFF
--- a/Library/Assets/PrivacyInfo.xcprivacy
+++ b/Library/Assets/PrivacyInfo.xcprivacy
@@ -15,5 +15,9 @@
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Hello,

While verifying the privacy manifest file of our app, I noticed that there is an error indicating that the manifest file of this library is missing NSPrivacyCollectedDataTypes key. 

![image](https://github.com/NordicSemiconductor/IOS-DFU-Library/assets/774945/5981ace9-db98-4ee1-8e32-267649a6d15f)

After adding the missing keys and empty values, the error was resolved. 

Furthermore, although there was no error regarding NSPrivacyTrackingDomains, I have added it following the Apple's library: https://github.com/apple/swift-protobuf/pull/1565/files

