### PR TITLE
PrivacyInfo bundle renamed for CocoaPods

### DIFF
--- a/iOSDFULibrary.podspec
+++ b/iOSDFULibrary.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "iOSDFULibrary"
   s.module_name      = 'NordicDFU'
-  s.version          = "4.15.1"
+  s.version          = "4.15.2"
   s.summary          = "This repository contains a library to perform Device Firmware Update on the nRF5x devices."
   s.description      = <<-DESC
 The nRF5x Series chips are flash-based SoCs, and as such they represent the most flexible solution available. A key feature of the nRF5x Series and their associated software architecture and S-Series SoftDevices is the possibility for Over-The-Air Device Firmware Upgrade (OTA-DFU). See Figure 1. OTA-DFU allows firmware upgrades to be issued and downloaded to products in the field via the cloud and so enables OEMs to fix bugs and introduce new features to products that are already out on the market. This brings added security and flexibility to product development when using the nRF5x Series SoCs.
@@ -22,7 +22,7 @@ The nRF5x Series chips are flash-based SoCs, and as such they represent the most
 
   s.source_files = 'Library/Classes/**/*'
   s.resource_bundles = {
-    'PrivacyInfo' => ['Library/Assets/PrivacyInfo.xcprivacy']
+    'NordicDFUPrivacyInfo' => ['Library/Assets/PrivacyInfo.xcprivacy']
   }
 
   s.dependency 'ZIPFoundation', '= 0.9.18'


### PR DESCRIPTION
This PR addresses an issue created here: https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/issues/611